### PR TITLE
Fix issues with draggable SegmentedButtons

### DIFF
--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -538,6 +538,15 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Update the selected button to the new position
                 moveSelectedButton(newPosition);
                 break;
+
+            case MotionEvent.ACTION_CANCEL:
+                // Cancel action is called when user leaves the view with their finger and another view captures the
+                // actions (e.g. scroll views for example)
+                // In this case, stop dragging and "snap" to nearest position
+                if (draggable) {
+                    setPosition(position, true);
+                }
+                break;
         }
 
         // Pretend like we never handled the touch event and pass to children (SegmentedButton)

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -492,19 +492,23 @@ public class SegmentedButtonGroup extends LinearLayout {
             return false;
         }
 
-        // Selected button position
-        final int position = getButtonPositionFromX(ev.getX());
-
         switch (ev.getAction()) {
-            case MotionEvent.ACTION_UP:
+            case MotionEvent.ACTION_UP: {
+                // Selected button position
+                final int position = getButtonPositionFromX(ev.getX());
+
                 // Go to the selected button on touch up and animate too
                 //
                 // In the case that the user has been dragging the button, this will have the effect of "snapping" to
                 // the nearest button
                 setPosition(position, true);
-                break;
+            }
+            break;
 
-            case MotionEvent.ACTION_DOWN:
+            case MotionEvent.ACTION_DOWN: {
+                // Selected button position
+                final int position = getButtonPositionFromX(ev.getX());
+
                 // If buttons cannot be dragged or if the user is NOT pressing the currently selected button, then
                 // just set the drag offset to be NaN meaning drag is not activated
                 if (!draggable || this.position != position) {
@@ -520,9 +524,13 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // moves their finger 50px, then the button should move 50px. Thus, this delta will be subtracted
                 // from the user's X value to get the location of where the button position should be.
                 dragOffsetX = ev.getX() - buttons.get(position).getLeft();
-                break;
+            }
+            break;
 
-            case MotionEvent.ACTION_MOVE:
+            case MotionEvent.ACTION_MOVE: {
+                // Selected button position
+                final int position = getButtonPositionFromX(ev.getX());
+
                 // Only drag if drag has been activated and hence is allowed
                 if (Float.isNaN(dragOffsetX)) {
                     break;
@@ -537,16 +545,18 @@ public class SegmentedButtonGroup extends LinearLayout {
 
                 // Update the selected button to the new position
                 moveSelectedButton(newPosition);
-                break;
+            }
+            break;
 
-            case MotionEvent.ACTION_CANCEL:
+            case MotionEvent.ACTION_CANCEL: {
                 // Cancel action is called when user leaves the view with their finger and another view captures the
                 // actions (e.g. scroll views for example)
                 // In this case, stop dragging and "snap" to nearest position
-                if (draggable) {
-                    setPosition(position, true);
+                if (!Float.isNaN(dragOffsetX)) {
+                    setPosition(Math.round(currentPosition), true);
                 }
-                break;
+            }
+            break;
         }
 
         // Pretend like we never handled the touch event and pass to children (SegmentedButton)

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -502,6 +502,9 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // In the case that the user has been dragging the button, this will have the effect of "snapping" to
                 // the nearest button
                 setPosition(position, true);
+
+                // Enable scroll touch event interception again now that we're done dragging
+                requestDisallowInterceptTouchEvent(false);
             }
             break;
 
@@ -515,6 +518,10 @@ public class SegmentedButtonGroup extends LinearLayout {
                     dragOffsetX = Float.NaN;
                     break;
                 }
+
+                // Since the user is now officially dragging the button, we want to disable scrolling interception
+                // of touch events
+                requestDisallowInterceptTouchEvent(true);
 
                 // Set drag offset in case user moves finger to initiate drag
                 // Drag offset is the difference between finger current X location and the location of the selected
@@ -554,6 +561,9 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // In this case, stop dragging and "snap" to nearest position
                 if (!Float.isNaN(dragOffsetX)) {
                     setPosition(Math.round(currentPosition), true);
+
+                    // Enable scroll touch event interception again now that we're done dragging
+                    requestDisallowInterceptTouchEvent(false);
                 }
             }
             break;

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -541,13 +541,13 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // moves their finger 50px, then the button should move 50px. Thus, this delta will be subtracted
                 // from the user's X value to get the location of where the button position should be.
                 dragOffsetX = ev.getX() - buttons.get(position).getLeft();
+
+                // Return here so that the touch event is not sent to the buttons
+                // This prevents the ripple effect from showing up when dragging
+                return true;
             }
-            break;
 
             case MotionEvent.ACTION_MOVE: {
-                // Selected button position
-                final int position = getButtonPositionFromX(ev.getX());
-
                 // Only drag if drag has been activated and hence is allowed
                 if (Float.isNaN(dragOffsetX)) {
                     break;


### PR DESCRIPTION
# Changes
* Fix issue with dragging buttons outside of the segmented button group bounds. Resolved by moving button to nearest position when user's finger leaves the segmented button group bounds.
* Fix issue that caused crash when user scrolled in a ScrollView starting with their finger on a segmented button
* Fix problem with ScrollView intercepting touch events while dragging. Resolved by disabling touch interception when dragging buttons.
* Prevent ripple effect when dragging buttons