### PR TITLE
Implement border and rounded corners for selected button

### DIFF
--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -1045,6 +1045,9 @@ public class SegmentedButton extends View {
             selectedButtonRadii = null;
         }
 
+        // Update background bitmaps
+        setupBackgroundBitmaps();
+
         invalidate();
     }
 
@@ -1057,8 +1060,6 @@ public class SegmentedButton extends View {
      * @param dashGap   Width of the gap for border, in pixels.
      */
     void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
-        // TODO Android preview border has a different radius than the selectedBackgroundRadius
-        // However problem is resolved when run on actual device
         if (width > 0) {
             // Allocate Paint object for drawing border here
             // Used in onDraw to draw the border around the selected button
@@ -1737,12 +1738,15 @@ public class SegmentedButton extends View {
                         BITMAP_CONFIG);
             }
 
-            // Create canvas using bitmap and draw the drawable on the canvas
+            // Create canvas using bitmap
             Canvas canvas = new Canvas(bitmap);
-            // Note: By changing the bounds on the drawable, this can have odd effects
-            // Currently not a problem but may be relevant later
+
+            // Draw the drawable on the canvas
+            // Save the bounds before hand and reset the drawable bounds afterwards
+            final Rect bounds = new Rect(drawable.getBounds());
             drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
             drawable.draw(canvas);
+            drawable.setBounds(bounds);
 
             return bitmap;
         } catch (Exception e) {

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -957,6 +957,8 @@ public class SegmentedButton extends View {
         if (backgroundDrawable != null) {
             backgroundBitmap = getBitmapFromDrawable(backgroundDrawable);
 
+            // TODO Figure out why this is null, its because intrinsic width/height is not right, hmm
+            //  But with the drawable not null, I do not see why it should not have an intrinsic width or height
             if (backgroundBitmap == null) {
                 Log.v(TAG, String.format("Null background: %d %d", backgroundDrawable.getIntrinsicWidth(),
                         backgroundDrawable.getIntrinsicHeight()));

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -564,7 +564,7 @@ public class SegmentedButton extends View {
         // The amount of the left or right side being shown is based on the relativeClippingPosition, a value from
         // 0.0f to 1.0f representing the relative position on the button.
         if (isClippingLeft) {
-            // If clipping the left, then the relativeClipPosition * width represents the right side of the selected
+            // If clipping the left, then relativeClipPosition * width represents the right side of the selected
             // button that is shown/clipped.
             //
             // The left side of the clip rectangle is set to be the relative clip position minus 1.0f times the width
@@ -641,7 +641,7 @@ public class SegmentedButton extends View {
             // will be incorrect.
             //
             // The rectangle is inset by half of the border width because the border width is centered about the
-            // rectangle bounds resulting in half of the border to be cut off since it is outside the clip path. In
+            // rectangle bounds resulting in half of the border being cut off since it is outside the clip path. In
             // addition, the inset is reduced by half a pixel (0.5f) to ensure there is no antialiasing bleed through
             // around the edge of the border.
             final float halfBorderWidth = selectedButtonBorderPaint.getStrokeWidth() / 2.0f;
@@ -958,6 +958,8 @@ public class SegmentedButton extends View {
      * @param dashGap   Width of the gap for border, in pixels.
      */
     void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
+        // TODO Android preview border has a different radius than the selectedBackgroundRadius
+        // However problem is resolved when run on actual device
         if (width > 0) {
             // Allocate Paint object for drawing border here
             // Used in onDraw to draw the border around the selected button

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -998,13 +998,13 @@ public class SegmentedButton extends View {
         setupBackgroundBitmaps();
     }
 
-    // TODO Explain here
     /**
-     * Explain here
+     * Setup the background paint objects so that the background & selected background drawable can be rendered with
+     * rounded corners using a bitmap shader
      *
-     * This function should be called when the background clip path changes (see setupBackgroundClipPath for details
-     * on what causes that to change), the background drawable or selected background drawable changes, the selected
-     * button radius changes, or the size of either the background or selected background drawable changes.
+     * This function is called by setupBackgroundClipPath since the background clip determines whether the button has
+     * rounded corners. In addition, this function should be called when the drawable or selected drawable changes,
+     * the selected button radius changes, or the size of either drawable changes.
      */
     void setupBackgroundBitmaps() {
         Bitmap bitmap;

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -618,14 +618,17 @@ public class SegmentedButton extends View {
             selectedClipPath.reset();
 
             selectedClipPath.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
-            canvas.clipPath(selectedClipPath);
+//            canvas.clipPath(selectedClipPath);
         } else {
-            canvas.clipRect(rectF);
         }
+        canvas.clipRect(rectF);
 
         // Draw background (selected)
         if (selectedBackgroundDrawable != null && selectedBackgroundBitmap != null) {
-            if (backgroundClipPath != null) {
+            if (selectedButtonRadius > 0 && selectedClipPath != null) {
+                canvas.drawPath(selectedClipPath, selectedBackgroundPaint);
+            } else if (backgroundClipPath != null) {
+//            if (backgroundClipPath != null) {
                 canvas.drawPath(backgroundClipPath, selectedBackgroundPaint);
             } else {
                 selectedBackgroundDrawable.draw(canvas);
@@ -688,6 +691,12 @@ public class SegmentedButton extends View {
 
         canvas.restore();
 
+        canvas.save();
+
+        if (backgroundClipPath != null) {
+            canvas.clipPath(backgroundClipPath);
+        }
+
         // Draw ripple drawable to show ripple effect on click
         if (rippleDrawableLollipop != null) {
             rippleDrawableLollipop.draw(canvas);
@@ -697,6 +706,8 @@ public class SegmentedButton extends View {
         if (rippleDrawable != null) {
             rippleDrawable.draw(canvas);
         }
+
+        canvas.restore();
     }
 
     /**
@@ -962,6 +973,7 @@ public class SegmentedButton extends View {
             if (backgroundBitmap == null) {
                 Log.v(TAG, String.format("Null background: %d %d", backgroundDrawable.getIntrinsicWidth(),
                         backgroundDrawable.getIntrinsicHeight()));
+                final int test = 7;
             }
 
             if (backgroundBitmap != null) {
@@ -1091,6 +1103,11 @@ public class SegmentedButton extends View {
         if (backgroundDrawable == null && drawable != null) {
             // Make sure to clone the drawable so that we can set the bounds on it
             backgroundDrawable = drawable.getConstantState().newDrawable();
+
+            // TODO getBounds()
+            Log.v(TAG, String.format("Testx: %d %d %d %d %d %d", drawable.getBounds().width(),
+                    drawable.getBounds().height()
+                    , drawable.getIntrinsicHeight(), drawable.getIntrinsicWidth(), getWidth(), getHeight()));
 
             // TODO Testing
             backgroundBitmap = getBitmapFromDrawable(drawable);

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -619,7 +619,6 @@ public class SegmentedButton extends View {
 
             selectedClipPath.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
 //            canvas.clipPath(selectedClipPath);
-        } else {
         }
         canvas.clipRect(rectF);
 
@@ -670,16 +669,22 @@ public class SegmentedButton extends View {
             final float halfBorderWidth = selectedButtonBorderPaint.getStrokeWidth() / 2.0f;
             rectF.inset(halfBorderWidth - 0.5f, halfBorderWidth - 0.5f);
 
+            Path test = new Path();
+            test.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
+
 //            rectF.inset(halfBorderWidth, halfBorderWidth);
             // This fixes displaying with no radius, anything else and border isnt shown
 //            rectF.inset(halfBorderWidth*2, halfBorderWidth*2);
 
             // Draw the border for the selected button
-            canvas.drawRoundRect(rectF, selectedButtonRadius - halfBorderWidth, selectedButtonRadius - halfBorderWidth,
-                    selectedButtonBorderPaint);
+//            canvas.drawRoundRect(rectF, (selectedButtonRadius - halfBorderWidth) / 1.37f,
+//                    selectedButtonRadius - halfBorderWidth,
+//                    selectedButtonBorderPaint);
+            canvas.drawPath(test, selectedButtonBorderPaint);
+//            canvas.drawRoundRect(rectF, selectedButtonRadius, selectedButtonRadius, selectedButtonBorderPaint);
             Log.v(TAG,
                     "Test: " + selectedButtonRadius + " " + selectedButtonBorderPaint.getStrokeWidth() + " "
-                            + halfBorderWidth);
+                            + halfBorderWidth + " " + isHardwareAccelerated() + " " + canvas.isHardwareAccelerated());
 
             Log.v(TAG, String.format("Meow: %d %d %d %d, (%f, %f, %f, %f)", getLeft(), getTop(), getWidth(),
                     getHeight(), rectF.left,

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -773,8 +773,8 @@ public class SegmentedButton extends View {
      * If both are true, then all corners will be rounded with the radius.
      * If none are set, no corners are rounded and this parameter is not used.
      *
-     * Note: You must manually call setupBackgroundClipPath after all changes to background radius, isLeftButton,
-     * isRightButton & width/height are completed.
+     * Note: You must manually call setupBackgroundClipPath after all changes to background radius, left button,
+     * right button & width/height are completed.
      *
      * @param backgroundRadius radius of corners of parent button group in pixels
      */
@@ -893,21 +893,27 @@ public class SegmentedButton extends View {
      */
     void setupSelectedButtonClipPath() {
         if (selectedButtonRadius > 0) {
+            // Setup clip path and the selected button radii
+            // These will be used in onDraw to draw the rounded selected button
+            // These objects are allocated here rather than in onDraw to increase performance
             selectedClipPath = new Path();
             selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
                     selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
                     selectedButtonRadius};
 
-            // Canvas.clipPath, used in onDraw for drawing the background clip path (rounding the edges for left-most and
-            // right-most buttons) is not supported with hardware acceleration until API 18
-            // Thus, switch to software acceleration if the current version is less than 18
+            // Canvas.clipPath, used in onDraw for drawing the selected button clip path is not supported with
+            // hardware acceleration until API 18. Thus, this switches to software acceleration if current Android
+            // API version is less than 18.
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 setLayerType(LAYER_TYPE_SOFTWARE, null);
             }
         } else {
+            // If the selected button radius is equal to zero, then corners will not be rounded
             selectedClipPath = null;
             selectedButtonRadii = null;
         }
+
+        invalidate();
     }
 
     /**
@@ -919,17 +925,20 @@ public class SegmentedButton extends View {
      * @param dashGap   Width of the gap for border, in pixels.
      */
     void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
-        // TODO Document
-        // TODO invalidate maybe?
         if (width > 0) {
+            // Allocate Paint object for drawing border here
+            // Used in onDraw to draw the border around the selected button
             selectedButtonBorderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             selectedButtonBorderPaint.setStyle(Paint.Style.STROKE);
             selectedButtonBorderPaint.setStrokeWidth(width);
             selectedButtonBorderPaint.setColor(color);
             selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[]{dashWidth, dashGap}, 0));
         } else {
+            // If the width is 0, then disable drawing border
             selectedButtonBorderPaint = null;
         }
+
+        invalidate();
     }
 
     /**

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -544,7 +544,8 @@ public class SegmentedButton extends View {
         float br = 45.0f;
         if (isClippingLeft) {
 //            rectF.set(0.0f, 0.0f, relativeClipPosition * width, height);
-            rectF.set(0.0f - (1.0f - relativeClipPosition) * width, 0.0f, relativeClipPosition * width, height);
+            rectF.set((relativeClipPosition - 1.0f) * width, 0.0f,
+                    relativeClipPosition * width, height);
             selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
             canvas.clipPath(selectedClipPath);
 
@@ -552,7 +553,7 @@ public class SegmentedButton extends View {
 //            canvas.clipRect(0.0f, 0.0f, relativeClipPosition * width, height);
         } else {
 //            rectF.set(relativeClipPosition * width, 0.0f, width, height);
-            rectF.set(relativeClipPosition * width, 0.0f, (1.0f + relativeClipPosition) * width, height);
+            rectF.set(relativeClipPosition * width, 0.0f, (relativeClipPosition + 1.0f) * width, height);
             selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
             canvas.clipPath(selectedClipPath);
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -6,6 +6,7 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.DashPathEffect;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Path.Direction;
@@ -55,7 +56,7 @@ public class SegmentedButton extends View {
     // General purpose rectangle to prevent memory allocation in onDraw
     private RectF rectF;
 
-    // Text paint variables contains paint info for unselected and selected text
+    // Text paint variable contains paint info for unselected and selected text
     private TextPaint textPaint;
     // Static layout used for positioning and drawing unselected and selected text
     private StaticLayout textStaticLayout;
@@ -81,6 +82,9 @@ public class SegmentedButton extends View {
     // TODO Document me
     private Path selectedClipPath;
     private float[] selectedButtonRadii;
+
+    // Paint information for how the border should be drawn for the selected button, null indicates no border
+    private Paint selectedButtonBorderPaint;
 
     // Horizontal relative clip position from 0.0f to 1.0f.
     // Value is scaled by the width of this view to get the actual clip X coordinate
@@ -602,15 +606,13 @@ public class SegmentedButton extends View {
 
         // 0.5f offset to prevent antialiasing bleed through, document this
         // TODO Document
-//        rectF.inset(5.0f - 0.5f, 5.0f - 0.5f);
-//
-//        Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-//        borderPaint.setStyle(Paint.Style.STROKE);
-//        borderPaint.setStrokeWidth(10);
-////        borderPaint.setPathEffect() DashedHere...
-//        borderPaint.setColor(Color.RED);
-//
-//        canvas.drawRoundRect(rectF, selectedButtonRadius - 5.0f, selectedButtonRadius - 5.0f, borderPaint);
+        if (selectedButtonBorderPaint != null) {
+            final float halfBorderWidth = selectedButtonBorderPaint.getStrokeWidth() / 2.0f;
+            rectF.inset(halfBorderWidth - 0.5f, halfBorderWidth - 0.5f);
+
+            canvas.drawRoundRect(rectF, selectedButtonRadius - halfBorderWidth, selectedButtonRadius - halfBorderWidth,
+                    selectedButtonBorderPaint);
+        }
 
         canvas.restore();
 
@@ -776,7 +778,7 @@ public class SegmentedButton extends View {
     }
 
     /**
-     * Returns whether this button is the left-most button in the group.
+     * Returns whether this button is the left-most button in the group
      *
      * This is determined based on whether the rightButton variable is null
      */
@@ -785,7 +787,7 @@ public class SegmentedButton extends View {
     }
 
     /**
-     * Returns whether this button is the right-most button in the group.
+     * Returns whether this button is the right-most button in the group
      *
      * This is determined based on whether the rightButton variable is null
      */
@@ -795,7 +797,8 @@ public class SegmentedButton extends View {
 
     /**
      * Sets the button directly to the left of this button. Set to null to indicate that this is the left-most button
-     * in the group.
+     * in the group
+     *
      * TODO Fix the below message
      * Note: You must manually call setupBackgroundClipPath after all changes to background radius, isLeftButton,
      * isRightButton & width/height are completed.
@@ -807,7 +810,7 @@ public class SegmentedButton extends View {
 
     /**
      * Sets the button directly to the right of this button. Set to null to indicate that this is the right-most button
-     * in the group.
+     * in the group
      *
      * Note: You must manually call setupBackgroundClipPath after all changes to background radius, isLeftButton,
      * isRightButton & width/height are completed.
@@ -885,11 +888,34 @@ public class SegmentedButton extends View {
 
     void setupSelectedButtonClipPath() {
         // TODO Document and fix me
+        // TODO Does this need updated on size change or anything...?
 
         selectedClipPath = new Path();
         selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
                 selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
                 selectedButtonRadius,};
+    }
+
+    /**
+     * Set the border for the selected button
+     *
+     * @param width     Width of the border in pixels (default value is 0px or no border)
+     * @param color     Color of the border (default color is black)
+     * @param dashWidth Width of the dash for border, in pixels. Value of 0px means solid line (default is 0px)
+     * @param dashGap   Width of the gap for border, in pixels.
+     */
+    void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
+        // TODO Document
+        // TODO invalidate maybe?
+        if (width > 0) {
+            selectedButtonBorderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+            selectedButtonBorderPaint.setStyle(Paint.Style.STROKE);
+            selectedButtonBorderPaint.setStrokeWidth(width);
+            selectedButtonBorderPaint.setColor(color);
+            selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[]{dashWidth, dashGap}, 0));
+        } else {
+            selectedButtonBorderPaint = null;
+        }
     }
 
     /**

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -91,6 +91,29 @@ public class SegmentedButton extends View {
     // correct side can be rounded out (if a background radius is specified)
     private SegmentedButton leftButton, rightButton;
 
+    // Bitmap created internally from the background drawable
+    // The bitmap, bitmap shader, and paint for the background are only used if the background has rounded corners
+    // (i.e. backgroundRadius > 0) and the button is either a left or right button (isLeftButton() || isRightButton())
+    // In cases where these items are not used, they are set to null
+    //
+    // The bitmap shader and paint are used to draw the background on a path to round the corners but also allow
+    // antialiasing
+    private Bitmap backgroundBitmap;
+    private BitmapShader backgroundBitmapShader;
+    private Paint backgroundPaint;
+
+    // TODO Fix me, this needs to be present if there is a selectedRadius or something too
+    // Bitmap created internally from the background drawable
+    // The bitmap, bitmap shader, and paint for the background are only used if the background has rounded corners
+    // (i.e. backgroundRadius > 0) and the button is either a left or right button (isLeftButton() || isRightButton())
+    // In cases where these items are not used, they are set to null
+    //
+    // The bitmap shader and paint are used to draw the background on a path to round the corners but also allow
+    // antialiasing
+    private Bitmap selectedBackgroundBitmap;
+    private BitmapShader selectedBackgroundBitmapShader;
+    private Paint selectedBackgroundPaint;
+
     // Radius of the selected button used for creating a rounded selected button
     private int selectedButtonRadius;
     // Clip path used to round the selected button to the specified radius
@@ -153,14 +176,6 @@ public class SegmentedButton extends View {
     private float textSize;
     // Typeface to use for displaying the text, this is created from the fontFamily & textStyle attributes
     private Typeface textTypeface;
-
-    // TODO Testing variables for new way of rounding edges
-    private Bitmap backgroundBitmap;
-    private BitmapShader backgroundBitmapShader;
-    private Paint backgroundPaint;
-    private Bitmap selectedBackgroundBitmap;
-    private BitmapShader selectedBackgroundBitmapShader;
-    private Paint selectedBackgroundPaint;
 
     // endregion
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -201,10 +201,6 @@ public class SegmentedButton extends View {
 
         // Required in order for this button to 'consume' the ripple touch event
         setClickable(true);
-
-        // TODO Testing stuff
-        backgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-        selectedBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
     }
 
     private void getAttributes(Context context, @Nullable AttributeSet attrs) {
@@ -546,9 +542,11 @@ public class SegmentedButton extends View {
 
         // Draw background (unselected)
         if (backgroundDrawable != null) {
-            canvas.drawPath(backgroundClipPath, backgroundPaint);
-        } else {
-            backgroundDrawable.draw(canvas);
+            if (backgroundClipPath != null && backgroundBitmap != null) {
+                canvas.drawPath(backgroundClipPath, backgroundPaint);
+            } else {
+                backgroundDrawable.draw(canvas);
+            }
         }
 
         // Draw text (unselected)
@@ -626,7 +624,7 @@ public class SegmentedButton extends View {
         }
 
         // Draw background (selected)
-        if (selectedBackgroundDrawable != null) {
+        if (selectedBackgroundDrawable != null && selectedBackgroundBitmap != null) {
             if (backgroundClipPath != null) {
                 canvas.drawPath(backgroundClipPath, selectedBackgroundPaint);
             } else {
@@ -956,11 +954,31 @@ public class SegmentedButton extends View {
         }
 
         // TODO Testing stuff
-        backgroundBitmapShader = new BitmapShader(backgroundBitmap, TileMode.CLAMP, TileMode.CLAMP);
-        backgroundPaint.setShader(backgroundBitmapShader);
+        if (backgroundDrawable != null) {
+            backgroundBitmap = getBitmapFromDrawable(backgroundDrawable);
 
-        selectedBackgroundBitmapShader = new BitmapShader(selectedBackgroundBitmap, TileMode.CLAMP, TileMode.CLAMP);
-        selectedBackgroundPaint.setShader(selectedBackgroundBitmapShader);
+            if (backgroundBitmap == null) {
+                Log.v(TAG, String.format("Null background: %d %d", backgroundDrawable.getIntrinsicWidth(),
+                        backgroundDrawable.getIntrinsicHeight()));
+            }
+
+            if (backgroundBitmap != null) {
+                backgroundBitmapShader = new BitmapShader(backgroundBitmap, TileMode.CLAMP, TileMode.CLAMP);
+                backgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                backgroundPaint.setShader(backgroundBitmapShader);
+            }
+        }
+
+        if (selectedBackgroundDrawable != null) {
+            selectedBackgroundBitmap = getBitmapFromDrawable(selectedBackgroundDrawable);
+
+            if (selectedBackgroundBitmap != null) {
+                selectedBackgroundBitmapShader = new BitmapShader(selectedBackgroundBitmap, TileMode.CLAMP,
+                        TileMode.CLAMP);
+                selectedBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+                selectedBackgroundPaint.setShader(selectedBackgroundBitmapShader);
+            }
+        }
     }
 
     private static Bitmap getBitmapFromDrawable(Drawable drawable) {
@@ -978,8 +996,12 @@ public class SegmentedButton extends View {
             if (drawable instanceof ColorDrawable) {
                 bitmap = Bitmap.createBitmap(COLORDRAWABLE_DIMENSION, COLORDRAWABLE_DIMENSION, BITMAP_CONFIG);
             } else {
-                bitmap = Bitmap
-                        .createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), BITMAP_CONFIG);
+                if (drawable.getIntrinsicWidth() <= 0 || drawable.getIntrinsicHeight() <= 0) {
+                    return null;
+                }
+
+                bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
+                        BITMAP_CONFIG);
             }
 
             Canvas canvas = new Canvas(bitmap);
@@ -1070,6 +1092,7 @@ public class SegmentedButton extends View {
 
             // TODO Testing
             backgroundBitmap = getBitmapFromDrawable(drawable);
+            setupBackgroundClipPath();
         }
     }
 
@@ -1091,6 +1114,7 @@ public class SegmentedButton extends View {
 
             // TODO Testing
             selectedBackgroundBitmap = getBitmapFromDrawable(drawable);
+            setupBackgroundClipPath();
         }
     }
 
@@ -1117,6 +1141,7 @@ public class SegmentedButton extends View {
 
         // TODO Testing
         backgroundBitmap = getBitmapFromDrawable(drawable);
+        setupBackgroundClipPath();
 
         invalidate();
     }
@@ -1139,6 +1164,7 @@ public class SegmentedButton extends View {
 
         // TODO Testing
         backgroundBitmap = getBitmapFromDrawable(drawable);
+        setupBackgroundClipPath();
 
         invalidate();
     }
@@ -1178,6 +1204,7 @@ public class SegmentedButton extends View {
 
         // TODO Testing
         selectedBackgroundBitmap = getBitmapFromDrawable(drawable);
+        setupBackgroundClipPath();
 
         invalidate();
     }
@@ -1200,6 +1227,7 @@ public class SegmentedButton extends View {
 
         // TODO Testing
         selectedBackgroundBitmap = getBitmapFromDrawable(drawable);
+        setupBackgroundClipPath();
 
         invalidate();
     }

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -688,7 +688,7 @@ public class SegmentedButton extends View {
             // Note: A path is used here rather than canvas.drawRoundRect because there was odd behavior on API 19
             // and particular devices where the border radius did not match the background radius.
             path.reset();
-            path.addRoundRect(rectF, selectedButtonRadius, selectedButtonRadius, Direction.CW);
+            path.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
 
             canvas.drawPath(path, selectedButtonBorderPaint);
         }
@@ -1027,22 +1027,19 @@ public class SegmentedButton extends View {
      * This function should be called if the selected button radius is changed
      */
     void setupSelectedButtonClipPath() {
-        if (selectedButtonRadius > 0) {
-            // Setup selected button radii
-            // Object allocated here rather than in onDraw to increase performance
-            selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                    selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                    selectedButtonRadius};
+        // Setup selected button radii
+        // Object allocated here rather than in onDraw to increase performance
+        selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+                selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+                selectedButtonRadius};
 
+        if (selectedButtonRadius > 0) {
             // Canvas.clipPath, used in onDraw for drawing the selected button clip path is not supported with
             // hardware acceleration until API 18. Thus, this switches to software acceleration if current Android
             // API version is less than 18.
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 setLayerType(LAYER_TYPE_SOFTWARE, null);
             }
-        } else {
-            // If the selected button radius is equal to zero, then corners will not be rounded
-            selectedButtonRadii = null;
         }
 
         // Update background bitmaps

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -553,7 +553,7 @@ public class SegmentedButton extends View {
         // TODO But not sure how I can add a border to things
         selectedClipPath.reset();
         if (isClippingLeft) {
-            float leftButtonWidth = isLeftButton() ? width : leftButton.getWidth();
+            final float leftButtonWidth = isLeftButton() ? width : leftButton.getWidth();
             rectF.set((relativeClipPosition - 1.0f) * leftButtonWidth, 0.0f, relativeClipPosition * width, height);
 
             // If clipping from left, go from 0.0f -> relativeClipPosition * width horizontally
@@ -564,7 +564,7 @@ public class SegmentedButton extends View {
                 canvas.clipRect(rectF);
             }
         } else {
-            float rightButtonWidth = isRightButton() ? width : rightButton.getWidth();
+            final float rightButtonWidth = isRightButton() ? width : rightButton.getWidth();
             rectF.set(relativeClipPosition * width, 0.0f, width + relativeClipPosition * rightButtonWidth, height);
 
             // If clipping from right, go from relativeClipPosition * width -> 1.0f horizontally
@@ -602,15 +602,15 @@ public class SegmentedButton extends View {
 
         // 0.5f offset to prevent antialiasing bleed through, document this
         // TODO Document
-        rectF.inset(5.0f - 0.5f, 5.0f - 0.5f);
-
-        Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-        borderPaint.setStyle(Paint.Style.STROKE);
-        borderPaint.setStrokeWidth(10);
-//        borderPaint.setPathEffect() DashedHere...
-        borderPaint.setColor(Color.RED);
-
-        canvas.drawRoundRect(rectF, selectedButtonRadius - 5.0f, selectedButtonRadius - 5.0f, borderPaint);
+//        rectF.inset(5.0f - 0.5f, 5.0f - 0.5f);
+//
+//        Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+//        borderPaint.setStyle(Paint.Style.STROKE);
+//        borderPaint.setStrokeWidth(10);
+////        borderPaint.setPathEffect() DashedHere...
+//        borderPaint.setColor(Color.RED);
+//
+//        canvas.drawRoundRect(rectF, selectedButtonRadius - 5.0f, selectedButtonRadius - 5.0f, borderPaint);
 
         canvas.restore();
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -73,8 +73,11 @@ public class SegmentedButton extends View {
     // Preferably segmented buttons shouldn't NEED to know about the buttons beside it, but there is a special case
     // where its required
     // In addition, this is used to determine whether this button is the left-most or right-most in the group so the
-    // correct side can be rounded out
+    // correct side can be rounded out (if a background radius is specified)
     private SegmentedButton leftButton, rightButton;
+
+    // Radius of the selected button used for creating a rounded selected button
+    private int selectedButtonRadius;
 
     // Horizontal relative clip position from 0.0f to 1.0f.
     // Value is scaled by the width of this view to get the actual clip X coordinate
@@ -553,7 +556,7 @@ public class SegmentedButton extends View {
 //            float xxx = (relativeClipPosition - 1.0f) * (isLeftButton() ? width : leftButton.getWidth());
             rectF.set((relativeClipPosition - 1.0f) * (isLeftButton() ? width : leftButton.getWidth()), 0.0f,
                     relativeClipPosition * width, height);
-            selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
+            selectedClipPath.addRoundRect(rectF, new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius}, Direction.CW);
             canvas.clipPath(selectedClipPath);
 
             // If clipping from left, go from 0.0f -> relativeClipPosition * width horizontally
@@ -563,7 +566,10 @@ public class SegmentedButton extends View {
 //            rectF.set(relativeClipPosition * width, 0.0f, width, height);
             rectF.set(relativeClipPosition * width, 0.0f, width + (relativeClipPosition) * (isRightButton() ?
                     width : rightButton.getWidth()), height);
-            selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
+            selectedClipPath.addRoundRect(rectF, new float[]{selectedButtonRadius, selectedButtonRadius,
+                            selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+                            selectedButtonRadius, selectedButtonRadius},
+                    Direction.CW);
             canvas.clipPath(selectedClipPath);
 
             // If clipping from right, go from relativeClipPosition * width -> 1.0f horizontally
@@ -613,7 +619,7 @@ public class SegmentedButton extends View {
         borderPaint.setColor(Color.RED);
 
 //        canvas.drawPath(selectedClipPath2, borderPaint);
-        canvas.drawRoundRect(rectF, br - 5.0f, br - 5.0f, borderPaint);
+        canvas.drawRoundRect(rectF, selectedButtonRadius - 5.0f, selectedButtonRadius - 5.0f, borderPaint);
 
         canvas.restore();
 
@@ -818,6 +824,18 @@ public class SegmentedButton extends View {
     @SuppressWarnings("SameParameterValue")
     void setRightButton(SegmentedButton rightButton) {
         this.rightButton = rightButton;
+    }
+
+    /**
+     * Set the radius of the selected button
+     *
+     * This will round out the selected button or the part shown in this button during animation based on this radius
+     * value.
+     *
+     * @param selectedButtonRadius radius of corners for selected button in pixels
+     */
+    void setSelectedButtonRadius(int selectedButtonRadius) {
+        this.selectedButtonRadius = selectedButtonRadius;
     }
 
     /**

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -25,6 +25,7 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -644,12 +645,27 @@ public class SegmentedButton extends View {
             // rectangle bounds resulting in half of the border being cut off since it is outside the clip path. In
             // addition, the inset is reduced by half a pixel (0.5f) to ensure there is no antialiasing bleed through
             // around the edge of the border.
+            // TODO Testing for API 19
             final float halfBorderWidth = selectedButtonBorderPaint.getStrokeWidth() / 2.0f;
             rectF.inset(halfBorderWidth - 0.5f, halfBorderWidth - 0.5f);
+
+//            rectF.inset(halfBorderWidth, halfBorderWidth);
+            // This fixes displaying with no radius, anything else and border isnt shown
+//            rectF.inset(halfBorderWidth*2, halfBorderWidth*2);
 
             // Draw the border for the selected button
             canvas.drawRoundRect(rectF, selectedButtonRadius - halfBorderWidth, selectedButtonRadius - halfBorderWidth,
                     selectedButtonBorderPaint);
+            Log.v(TAG,
+                    "Test: " + selectedButtonRadius + " " + selectedButtonBorderPaint.getStrokeWidth() + " "
+                            + halfBorderWidth);
+
+            Log.v(TAG, String.format("Meow: %d %d %d %d, (%f, %f, %f, %f)", getLeft(), getTop(), getWidth(),
+                    getHeight(), rectF.left,
+                    rectF.top, rectF.width(), rectF.height()));
+//            canvas.drawRoundRect(rectF, selectedButtonRadius - halfBorderWidth * 2,
+//                    selectedButtonRadius - halfBorderWidth * 2,
+//                    selectedButtonBorderPaint);
         }
 
         canvas.restore();

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -78,6 +78,9 @@ public class SegmentedButton extends View {
 
     // Radius of the selected button used for creating a rounded selected button
     private int selectedButtonRadius;
+    // TODO Document me
+    private Path selectedClipPath;
+    private float[] selectedButtonRadii;
 
     // Horizontal relative clip position from 0.0f to 1.0f.
     // Value is scaled by the width of this view to get the actual clip X coordinate
@@ -545,43 +548,36 @@ public class SegmentedButton extends View {
         canvas.save();
 
         // Clip canvas for drawing the selected button view
+        // TODO Document here
         // TODO Clip a rounded rect now instead...
         // TODO But not sure how I can add a border to things
-        Path selectedClipPath = new Path();
-        float br = 45.0f;
+        selectedClipPath.reset();
         if (isClippingLeft) {
-            // buttonLeft.getWidth()
-            // leftWidth here...
-//            rectF.set(0.0f, 0.0f, relativeClipPosition * width, height);
-//            float xxx = (relativeClipPosition - 1.0f) * (isLeftButton() ? width : leftButton.getWidth());
-            rectF.set((relativeClipPosition - 1.0f) * (isLeftButton() ? width : leftButton.getWidth()), 0.0f,
-                    relativeClipPosition * width, height);
-            selectedClipPath.addRoundRect(rectF, new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius}, Direction.CW);
-            canvas.clipPath(selectedClipPath);
+            float leftButtonWidth = isLeftButton() ? width : leftButton.getWidth();
+            rectF.set((relativeClipPosition - 1.0f) * leftButtonWidth, 0.0f, relativeClipPosition * width, height);
 
             // If clipping from left, go from 0.0f -> relativeClipPosition * width horizontally
-//            canvas.clipRect(0.0f, 0.0f, relativeClipPosition * width, height);
+            if (selectedButtonRadius > 0) {
+                selectedClipPath.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
+                canvas.clipPath(selectedClipPath);
+            } else {
+                canvas.clipRect(rectF);
+            }
         } else {
-            // buttonRight.getWidth()
-//            rectF.set(relativeClipPosition * width, 0.0f, width, height);
-            rectF.set(relativeClipPosition * width, 0.0f, width + (relativeClipPosition) * (isRightButton() ?
-                    width : rightButton.getWidth()), height);
-            selectedClipPath.addRoundRect(rectF, new float[]{selectedButtonRadius, selectedButtonRadius,
-                            selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                            selectedButtonRadius, selectedButtonRadius},
-                    Direction.CW);
-            canvas.clipPath(selectedClipPath);
+            float rightButtonWidth = isRightButton() ? width : rightButton.getWidth();
+            rectF.set(relativeClipPosition * width, 0.0f, width + relativeClipPosition * rightButtonWidth, height);
 
             // If clipping from right, go from relativeClipPosition * width -> 1.0f horizontally
-//            canvas.clipRect(relativeClipPosition * width, 0.0f, width, height);
+            if (selectedButtonRadius > 0) {
+                selectedClipPath.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
+                canvas.clipPath(selectedClipPath);
+            } else {
+                canvas.clipRect(rectF);
+            }
         }
 
         // Draw background (selected)
         if (selectedBackgroundDrawable != null) {
-//            selectedBackgroundDrawable.setBounds(0 + 10, 0 + 10,
-//                    getWidth() - 10,
-//                    getHeight() - 10);
-
             selectedBackgroundDrawable.draw(canvas);
         }
 
@@ -604,21 +600,16 @@ public class SegmentedButton extends View {
             drawable.draw(canvas);
         }
 
-//        canvas.restore();
-
-//        Path selectedClipPath2 = new Path();
+        // 0.5f offset to prevent antialiasing bleed through, document this
+        // TODO Document
         rectF.inset(5.0f - 0.5f, 5.0f - 0.5f);
-//        rectF.inset(5.0f, 5.0f);
-//        selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
 
         Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-//        Paint borderPaint = new Paint();
         borderPaint.setStyle(Paint.Style.STROKE);
         borderPaint.setStrokeWidth(10);
-//        borderPaint.setDas
+//        borderPaint.setPathEffect() DashedHere...
         borderPaint.setColor(Color.RED);
 
-//        canvas.drawPath(selectedClipPath2, borderPaint);
         canvas.drawRoundRect(rectF, selectedButtonRadius - 5.0f, selectedButtonRadius - 5.0f, borderPaint);
 
         canvas.restore();
@@ -890,6 +881,15 @@ public class SegmentedButton extends View {
         } else {
             setLayerType(View.LAYER_TYPE_HARDWARE, null);
         }
+    }
+
+    void setupSelectedButtonClipPath() {
+        // TODO Document and fix me
+
+        selectedClipPath = new Path();
+        selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+                selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+                selectedButtonRadius,};
     }
 
     /**

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -538,12 +538,26 @@ public class SegmentedButton extends View {
         canvas.save();
 
         // Clip canvas for drawing the selected button view
+        // TODO Clip a rounded rect now instead...
+        // TODO But not sure how I can add a border to things
+        Path selectedClipPath = new Path();
+        float br = 45.0f;
         if (isClippingLeft) {
+//            rectF.set(0.0f, 0.0f, relativeClipPosition * width, height);
+            rectF.set(0.0f - (1.0f - relativeClipPosition) * width, 0.0f, relativeClipPosition * width, height);
+            selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
+            canvas.clipPath(selectedClipPath);
+
             // If clipping from left, go from 0.0f -> relativeClipPosition * width horizontally
-            canvas.clipRect(0.0f, 0.0f, relativeClipPosition * width, height);
+//            canvas.clipRect(0.0f, 0.0f, relativeClipPosition * width, height);
         } else {
+//            rectF.set(relativeClipPosition * width, 0.0f, width, height);
+            rectF.set(relativeClipPosition * width, 0.0f, (1.0f + relativeClipPosition) * width, height);
+            selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
+            canvas.clipPath(selectedClipPath);
+
             // If clipping from right, go from relativeClipPosition * width -> 1.0f horizontally
-            canvas.clipRect(relativeClipPosition * width, 0.0f, width, height);
+//            canvas.clipRect(relativeClipPosition * width, 0.0f, width, height);
         }
 
         // Draw background (selected)

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -6,6 +6,7 @@ import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Path.Direction;
 import android.graphics.PointF;
@@ -563,6 +564,10 @@ public class SegmentedButton extends View {
 
         // Draw background (selected)
         if (selectedBackgroundDrawable != null) {
+//            selectedBackgroundDrawable.setBounds(0 + 10, 0 + 10,
+//                    getWidth() - 10,
+//                    getHeight() - 10);
+
             selectedBackgroundDrawable.draw(canvas);
         }
 
@@ -584,6 +589,23 @@ public class SegmentedButton extends View {
             drawable.setColorFilter(hasSelectedDrawableTint ? selectedDrawableColorFilter : drawableColorFilter);
             drawable.draw(canvas);
         }
+
+//        canvas.restore();
+
+//        Path selectedClipPath2 = new Path();
+        rectF.inset(5.0f - 0.5f, 5.0f - 0.5f);
+//        rectF.inset(5.0f, 5.0f);
+//        selectedClipPath.addRoundRect(rectF, new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
+
+        Paint borderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+//        Paint borderPaint = new Paint();
+        borderPaint.setStyle(Paint.Style.STROKE);
+        borderPaint.setStrokeWidth(10);
+//        borderPaint.setDas
+        borderPaint.setColor(Color.RED);
+
+//        canvas.drawPath(selectedClipPath2, borderPaint);
+        canvas.drawRoundRect(rectF, br - 5.0f, br - 5.0f, borderPaint);
 
         canvas.restore();
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -416,9 +416,6 @@ public class SegmentedButton extends View {
 
         // Recalculate the background clip path since width & height have changed
         setupBackgroundClipPath();
-
-        // TODO Explain this
-        setupBackgroundBitmaps();
     }
 
     /**
@@ -1115,11 +1112,6 @@ public class SegmentedButton extends View {
         if (backgroundDrawable == null && drawable != null) {
             // Make sure to clone the drawable so that we can set the bounds on it
             backgroundDrawable = drawable.getConstantState().newDrawable();
-
-            // TODO getBounds()
-            Log.v(TAG, String.format("Testx: %d %d %d %d %d %d", drawable.getBounds().width(),
-                    drawable.getBounds().height()
-                    , drawable.getIntrinsicHeight(), drawable.getIntrinsicWidth(), getWidth(), getHeight()));
         }
     }
 
@@ -1160,10 +1152,9 @@ public class SegmentedButton extends View {
     @Override
     public void setBackground(final Drawable drawable) {
         backgroundDrawable = drawable;
-//        backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
+        backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
 
-        // TODO Testing, probably should have setupBackgroundBitmaps
-        setupBackgroundClipPath();
+        // Setup the background bitmaps again since background drawable has changed
         setupBackgroundBitmaps();
 
         invalidate();
@@ -1182,11 +1173,10 @@ public class SegmentedButton extends View {
             ((ColorDrawable) backgroundDrawable.mutate()).setColor(color);
         } else {
             backgroundDrawable = new ColorDrawable(color);
-//            backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
+            backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
         }
 
-        // TODO Testing, probably should have setupBackgroundBitmaps
-        setupBackgroundClipPath();
+        // Setup the background bitmaps again since background drawable has changed
         setupBackgroundBitmaps();
 
         invalidate();
@@ -1223,10 +1213,9 @@ public class SegmentedButton extends View {
      */
     public void setSelectedBackground(final Drawable drawable) {
         selectedBackgroundDrawable = drawable;
-//        selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
+        selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
 
-        // TODO Testing
-        setupBackgroundClipPath();
+        // Setup the background bitmaps again since background drawable has changed
         setupBackgroundBitmaps();
 
         invalidate();
@@ -1245,11 +1234,10 @@ public class SegmentedButton extends View {
             ((ColorDrawable) selectedBackgroundDrawable.mutate()).setColor(color);
         } else {
             selectedBackgroundDrawable = new ColorDrawable(color);
-//            selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
+            selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
         }
 
-        // TODO Testing
-        setupBackgroundClipPath();
+        // Setup the background bitmaps again since background drawable has changed
         setupBackgroundBitmaps();
 
         invalidate();

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -716,7 +716,8 @@ public class SegmentedButton extends View {
 
         canvas.save();
 
-        // TODO Explain this
+        // Clip to the background clip path if available
+        // This is used so the ripple effect will stop at the rounded corners of the background
         if (backgroundClipPath != null) {
             canvas.clipPath(backgroundClipPath);
         }
@@ -948,16 +949,17 @@ public class SegmentedButton extends View {
      *
      * This function should be called when the size of the button changes, if the background radius changes and/or if
      * the isLeftButton() or isRightButton() boolean values change.
+     *
+     * Note that this function internally calls setupBackgroundBitmaps() because a change in the clip path will
+     * require updating the bitmaps
      */
     void setupBackgroundClipPath() {
-        // TODO Better naming if I end up using new method
         // If there is no background radius then skip
         if (backgroundRadius == 0) {
             backgroundClipPath = null;
 
-            // TODO Better
+            // Update background bitmaps
             setupBackgroundBitmaps();
-
             return;
         }
 
@@ -992,9 +994,11 @@ public class SegmentedButton extends View {
             setLayerType(LAYER_TYPE_SOFTWARE, null);
         }
 
+        // Update background bitmaps
         setupBackgroundBitmaps();
     }
 
+    // TODO Explain here
     /**
      * Explain here
      *
@@ -1003,17 +1007,12 @@ public class SegmentedButton extends View {
      * button radius changes, or the size of either the background or selected background drawable changes.
      */
     void setupBackgroundBitmaps() {
-        // TODO Testing stuff
-        // TODO Consider renaming this and bringing together with setupBackgroundClipPath
-
-        // Note: Either one of these can be null before getSize is done correctly, so this means backgroundPaint and
-        // backgroundBitmap will be null.
-        //
-        // Besides that, I can assume a lot of things will NOT be null if something is set
-
         Bitmap bitmap;
 
-        // Do if backgroundRadius > 0
+        // Setup background paint object to render background using a bitmap shader approach under three conditions:
+        //      1. Background has rounded corners
+        //      2. There is a background drawable
+        //      3. Able to successfully create bitmap from drawable
         if (backgroundClipPath != null && backgroundDrawable != null
                 && (bitmap = getBitmapFromDrawable(backgroundDrawable)) != null) {
             final BitmapShader backgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP, TileMode.CLAMP);
@@ -1024,7 +1023,11 @@ public class SegmentedButton extends View {
             backgroundPaint = null;
         }
 
-        // Do if backgroundRadius > 0 OR selectedButtonRadius > 0
+        // Setup selected background paint object to render background using a bitmap shader approach under three
+        // conditions:
+        //      1. Background has rounded corners OR selected button has rounded corners
+        //      2. There is a background drawable
+        //      3. Able to successfully create bitmap from drawable
         if ((backgroundClipPath != null || selectedButtonRadius > 0) && selectedBackgroundDrawable != null
                 && (bitmap = getBitmapFromDrawable(selectedBackgroundDrawable)) != null) {
             final BitmapShader selectedBackgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP,

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -965,7 +965,10 @@ public class SegmentedButton extends View {
             selectedButtonBorderPaint.setStyle(Paint.Style.STROKE);
             selectedButtonBorderPaint.setStrokeWidth(width);
             selectedButtonBorderPaint.setColor(color);
-            selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[]{dashWidth, dashGap}, 0));
+
+            if (dashWidth > 0.0f) {
+                selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[]{dashWidth, dashGap}, 0));
+            }
         } else {
             // If the width is 0, then disable drawing border
             selectedButtonBorderPaint = null;

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -115,6 +115,8 @@ public class SegmentedButtonGroup extends LinearLayout {
 
     // Radius for rounding edges of the button group, in pixels (default value is 0)
     private int radius;
+    // Radius for rounding edges of the selected button, in pixels (default value is 0)
+    private int selectedButtonRadius;
 
     // Position of the currently selected button, zero-indexed (default value is 0)
     // When animating, the position will be the previous value until after animation is finished
@@ -276,6 +278,7 @@ public class SegmentedButtonGroup extends LinearLayout {
 
         // Note: Must read radius before setBorder call in order to round the border corners!
         radius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_radius, 0);
+        selectedButtonRadius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedButtonRadius, 0);
 
         // Setup border for button group
         // Width is the thickness of the border, color is the color of the border
@@ -359,6 +362,7 @@ public class SegmentedButtonGroup extends LinearLayout {
             // The default backgrounds will only update the background of the button if there is not a background set
             // on that button explicitly
             button.setBackgroundRadius(radius);
+            button.setSelectedButtonRadius(selectedButtonRadius);
             button.setDefaultBackground(backgroundDrawable);
             button.setDefaultSelectedBackground(selectedBackgroundDrawable);
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -374,23 +374,20 @@ public class SegmentedButtonGroup extends LinearLayout {
                 button.setRipple(false);
             }
 
+            // TODO Redocument
             // If this is the first item, set it as left-most button
             // Otherwise, notify previous button that it is not right-most anymore
-            if (position == 0) {
-                button.setIsLeftButton(true);
-            } else {
+            if (position != 0) {
                 // Update previous button that it is not right-most anymore
                 final SegmentedButton oldButton = buttons.get(position - 1);
 
-                oldButton.setIsRightButton(false);
+                 oldButton.setRightButton(button);
+                 button.setLeftButton(oldButton);
 
                 // Update the background clip path for that button (removes rounding edges since it's not the
                 // right-most button anymore)
                 oldButton.setupBackgroundClipPath();
             }
-
-            // Set current button as right-most
-            button.setIsRightButton(true);
 
             // Sets up the background clip path in order to correctly round background to match the radius
             button.setupBackgroundClipPath();

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -18,6 +18,7 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
@@ -1057,8 +1058,6 @@ public class SegmentedButtonGroup extends LinearLayout {
         for (SegmentedButton button : buttons) {
             button.setSelectedButtonRadius(selectedButtonRadius);
             button.setupSelectedButtonClipPath();
-
-            button.invalidate();
         }
     }
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -413,6 +413,8 @@ public class SegmentedButtonGroup extends LinearLayout {
 
             // TODO We do this because the background radius is changed
             button.setupSelectedButtonClipPath();
+            button.setSelectedButtonBorder(selectedBorderWidth, selectedBorderColor, selectedBorderDashWidth,
+                    selectedBorderDashGap);
 
             // Add the button to the main group instead and store the button in our buttons list
             buttonLayout.addView(button, params);
@@ -1001,10 +1003,10 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param dashGap   Width of the gap for border, in pixels.
      */
     public void setSelectedBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
-        borderWidth = width;
-        borderColor = color;
-        borderDashWidth = dashWidth;
-        borderDashGap = dashGap;
+        selectedBorderWidth = width;
+        selectedBorderColor = color;
+        selectedBorderDashWidth = dashWidth;
+        selectedBorderDashGap = dashGap;
 
         // TODO Fix me here, pass to all buttons
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -956,6 +956,75 @@ public class SegmentedButtonGroup extends LinearLayout {
     }
 
     /**
+     * Return the width of the border for the selected button, in pixels
+     *
+     * 0px value indicates no border is present
+     */
+    public int getSelectedBorderWidth() {
+        return selectedBorderWidth;
+    }
+
+    /**
+     * Return color of the border for the selected button
+     */
+    public int getSelectedBorderColor() {
+        return selectedBorderColor;
+    }
+
+    /**
+     * Return the border dash width for the selected button, in pixels
+     *
+     * 0px value indicates the border is solid
+     */
+    public int getSelectedBorderDashWidth() {
+        return selectedBorderDashWidth;
+    }
+
+    /**
+     * Return the border gap width for the selected button, in pixels
+     *
+     * Only relevant if border dash width is greater than 0px
+     */
+    public int getSelectedBorderDashGap() {
+        return selectedBorderDashGap;
+    }
+
+    /**
+     * Set the border for the selected button.
+     *
+     * @param width     Width of the border in pixels (default value is 0px or no border)
+     * @param color     Color of the border (default color is black)
+     * @param dashWidth Width of the dash for border, in pixels. Value of 0px means solid line (default is 0px)
+     * @param dashGap   Width of the gap for border, in pixels.
+     */
+    public void setSelectedBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
+        borderWidth = width;
+        borderColor = color;
+        borderDashWidth = dashWidth;
+        borderDashGap = dashGap;
+
+        // TODO Fix me here, pass to all buttons
+
+//        // Border width of 0 indicates to hide borders
+//        if (width > 0) {
+//            GradientDrawable borderDrawable = new GradientDrawable();
+//            // Set background color to be transparent so that buttons and everything underneath the border view is
+//            // still visible. This was an issue on API 16 Android where it would default to a black background
+//            borderDrawable.setColor(Color.TRANSPARENT);
+//            // Corner radius is the radius minus half of the border width because the drawable will draw the stroke
+//            // from the center, so the actual corner radius is reduced
+//            // If the half border width is left out, the border radius does not follow the curve of the background
+//            borderDrawable.setCornerRadius(radius - width / 2.0f);
+//            borderDrawable.setStroke(width, color, dashWidth, dashGap);
+//
+//            borderView.setBackground(borderDrawable);
+//        } else {
+//            borderView.setBackground(null);
+//        }
+    }
+
+
+    /**
      * Returns the current corner radius for this button group, in pixels
      *
      * A value of 0px indicates the view is rectangular and has no rounded corners

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -18,11 +18,9 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.view.animation.AccelerateDecelerateInterpolator;
@@ -129,10 +127,6 @@ public class SegmentedButtonGroup extends LinearLayout {
     // Position of the currently selected button, zero-indexed (default value is 0)
     // When animating, the position will be the previous value until after animation is finished
     private int position;
-
-    // Configuration value from Android that determines how far a user must move their finger before a touch is
-    // considered a drag
-    private int touchSlop;
 
     // Whether or not the button can be dragged to a different position (default value is false)
     private boolean draggable;
@@ -261,11 +255,6 @@ public class SegmentedButtonGroup extends LinearLayout {
 
         // Retrieve custom attributes
         getAttributes(context, attrs);
-
-        // Retrieve the touch slop from Android configuration
-        // This is the same value used by ScrollView to determine when a user is scrolling vs just tapping
-        final ViewConfiguration configuration = ViewConfiguration.get(context);
-        touchSlop = configuration.getScaledTouchSlop();
     }
 
     private void getAttributes(Context context, @Nullable AttributeSet attrs) {
@@ -576,11 +565,6 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Get X coordinate of where the selected button should be by taking user's X location and subtract
                 // the offset
                 float xCoord = ev.getX() - dragOffsetX;
-
-                // Do not move the button until the user has moved their finger enough
-                if (Math.abs(xCoord) < touchSlop) {
-                    break;
-                }
 
                 // Convert X coordinate to a position containing the relative offset within the button as well
                 // Clip the position to be between 0.0f and buttons size minus 1 so that the user doesn't drag out of

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -396,14 +396,10 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Update the background clip path for that button (removes rounding edges since it's not the
                 // right-most button anymore)
                 oldButton.setupBackgroundClipPath();
-                // TODO Document why
-                oldButton.setupBackgroundBitmaps();
             }
 
             // Sets up the background clip path, selected button clip path, and selected button border
             button.setupBackgroundClipPath();
-            // TODO Document why
-            button.setupBackgroundBitmaps();
             button.setupSelectedButtonClipPath();
             button.setSelectedButtonBorder(selectedBorderWidth, selectedBorderColor, selectedBorderDashWidth,
                     selectedBorderDashGap);

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -396,10 +396,14 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Update the background clip path for that button (removes rounding edges since it's not the
                 // right-most button anymore)
                 oldButton.setupBackgroundClipPath();
+                // TODO Document why
+                oldButton.setupBackgroundBitmaps();
             }
 
             // Sets up the background clip path, selected button clip path, and selected button border
             button.setupBackgroundClipPath();
+            // TODO Document why
+            button.setupBackgroundBitmaps();
             button.setupSelectedButtonClipPath();
             button.setSelectedButtonBorder(selectedBorderWidth, selectedBorderColor, selectedBorderDashWidth,
                     selectedBorderDashGap);

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -18,6 +18,7 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
@@ -582,7 +583,9 @@ public class SegmentedButtonGroup extends LinearLayout {
                 }
 
                 // Convert X coordinate to a position containing the relative offset within the button as well
-                final float newPosition = getButtonPositionFromXF(xCoord);
+                // Clip the position to be between 0.0f and buttons size minus 1 so that the user doesn't drag out of
+                // bounds
+                final float newPosition = Math.min(Math.max(getButtonPositionFromXF(xCoord), 0.0f), buttons.size() - 1);
 
                 // Update the selected button to the new position
                 moveSelectedButton(newPosition);

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -411,6 +411,9 @@ public class SegmentedButtonGroup extends LinearLayout {
             // Sets up the background clip path in order to correctly round background to match the radius
             button.setupBackgroundClipPath();
 
+            // TODO We do this because the background radius is changed
+            button.setupSelectedButtonClipPath();
+
             // Add the button to the main group instead and store the button in our buttons list
             buttonLayout.addView(button, params);
             buttons.add(button);

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -1102,7 +1102,6 @@ public class SegmentedButtonGroup extends LinearLayout {
      * nearest button
      */
     public void setDraggable(final boolean draggable) {
-        // TODO Fix draggable bug where finger leaves button group, exit focus event?
         this.draggable = draggable;
     }
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -373,7 +373,7 @@ public class SegmentedButtonGroup extends LinearLayout {
             // For example, if there are 5 buttons, then the indices are 0, 1, 2, 3, 4, so the next index is 5!
             final int position = buttons.size();
 
-            // Give radius, default background and default selected background to the button
+            // Give radius, selected button radius, default background and default selected background to the button
             // The default backgrounds will only update the background of the button if there is not a background set
             // on that button explicitly
             button.setBackgroundRadius(radius);
@@ -393,13 +393,13 @@ public class SegmentedButtonGroup extends LinearLayout {
                 button.setRipple(false);
             }
 
-            // TODO Redocument
-            // If this is the first item, set it as left-most button
-            // Otherwise, notify previous button that it is not right-most anymore
+            // If this is NOT the first item in the group, then update the previous button and this button with its
+            // respective right button and left button.
             if (position != 0) {
-                // Update previous button that it is not right-most anymore
                 final SegmentedButton oldButton = buttons.get(position - 1);
 
+                // Old button's right button is this new button
+                // This button's left button is the old button
                 oldButton.setRightButton(button);
                 button.setLeftButton(oldButton);
 
@@ -408,10 +408,8 @@ public class SegmentedButtonGroup extends LinearLayout {
                 oldButton.setupBackgroundClipPath();
             }
 
-            // Sets up the background clip path in order to correctly round background to match the radius
+            // Sets up the background clip path, selected button clip path, and selected button border
             button.setupBackgroundClipPath();
-
-            // TODO We do this because the background radius is changed
             button.setupSelectedButtonClipPath();
             button.setSelectedButtonBorder(selectedBorderWidth, selectedBorderColor, selectedBorderDashWidth,
                     selectedBorderDashGap);
@@ -1008,26 +1006,11 @@ public class SegmentedButtonGroup extends LinearLayout {
         selectedBorderDashWidth = dashWidth;
         selectedBorderDashGap = dashGap;
 
-        // TODO Fix me here, pass to all buttons
-
-//        // Border width of 0 indicates to hide borders
-//        if (width > 0) {
-//            GradientDrawable borderDrawable = new GradientDrawable();
-//            // Set background color to be transparent so that buttons and everything underneath the border view is
-//            // still visible. This was an issue on API 16 Android where it would default to a black background
-//            borderDrawable.setColor(Color.TRANSPARENT);
-//            // Corner radius is the radius minus half of the border width because the drawable will draw the stroke
-//            // from the center, so the actual corner radius is reduced
-//            // If the half border width is left out, the border radius does not follow the curve of the background
-//            borderDrawable.setCornerRadius(radius - width / 2.0f);
-//            borderDrawable.setStroke(width, color, dashWidth, dashGap);
-//
-//            borderView.setBackground(borderDrawable);
-//        } else {
-//            borderView.setBackground(null);
-//        }
+        // Loop through each button and set the selected button border
+        for (SegmentedButton button : buttons) {
+            button.setSelectedButtonBorder(width, color, dashWidth, dashGap);
+        }
     }
-
 
     /**
      * Returns the current corner radius for this button group, in pixels
@@ -1083,7 +1066,13 @@ public class SegmentedButtonGroup extends LinearLayout {
     public void setSelectedButtonRadius(int selectedButtonRadius) {
         this.selectedButtonRadius = selectedButtonRadius;
 
-        // TODO Fix me, update the radius for each button
+        // Update the selected button radius for each button
+        for (SegmentedButton button : buttons) {
+            button.setSelectedButtonRadius(selectedButtonRadius);
+            button.setupSelectedButtonClipPath();
+
+            button.invalidate();
+        }
     }
 
     /**

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -113,6 +113,13 @@ public class SegmentedButtonGroup extends LinearLayout {
     // Width of the gap for border, in pixels. Only relevant when dashWidth is greater than 0px
     private int borderDashGap;
 
+    // This is the border information for the selected button with the same defaults as above for the button group
+    // border
+    private int selectedBorderWidth;
+    private int selectedBorderColor;
+    private int selectedBorderDashWidth;
+    private int selectedBorderDashGap;
+
     // Radius for rounding edges of the button group, in pixels (default value is 0)
     private int radius;
     // Radius for rounding edges of the selected button, in pixels (default value is 0)
@@ -293,6 +300,14 @@ public class SegmentedButtonGroup extends LinearLayout {
         // GradientDrawable containing the border
         setBorder(borderWidth, borderColor, borderDashWidth, borderDashGap);
 
+        // Get border information for the selected button
+        // Same defaults as the border above, however this border information will be passed to each button so that
+        // the correct border can be rendered around the selected button
+        selectedBorderWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderWidth, 0);
+        selectedBorderColor = ta.getColor(R.styleable.SegmentedButtonGroup_selectedBorderColor, Color.BLACK);
+        selectedBorderDashWidth = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderDashWidth, 0);
+        selectedBorderDashGap = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_selectedBorderDashGap, 0);
+
         position = ta.getInt(R.styleable.SegmentedButtonGroup_position, 0);
         draggable = ta.getBoolean(R.styleable.SegmentedButtonGroup_draggable, false);
 
@@ -385,8 +400,8 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Update previous button that it is not right-most anymore
                 final SegmentedButton oldButton = buttons.get(position - 1);
 
-                 oldButton.setRightButton(button);
-                 button.setLeftButton(oldButton);
+                oldButton.setRightButton(button);
+                button.setLeftButton(oldButton);
 
                 // Update the background clip path for that button (removes rounding edges since it's not the
                 // right-most button anymore)
@@ -975,6 +990,26 @@ public class SegmentedButtonGroup extends LinearLayout {
         if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
             invalidateOutline();
         }
+    }
+
+    /**
+     * Returns the current corner radius for the selected button, in pixels
+     *
+     * A value of 0px indicates the selected button will be rectangular and has no rounded corners
+     */
+    public int getSelectedButtonRadius() {
+        return selectedButtonRadius;
+    }
+
+    /**
+     * Sets the corner radius for the selected button
+     *
+     * @param selectedButtonRadius value of the new selected button corner radius, in pixels
+     */
+    public void setSelectedButtonRadius(int selectedButtonRadius) {
+        this.selectedButtonRadius = selectedButtonRadius;
+
+        // TODO Fix me, update the radius for each button
     }
 
     /**

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -46,6 +46,11 @@
         <attr name="borderDashWidth" format="dimension" />
         <attr name="borderDashGap" format="dimension" />
 
+        <attr name="selectedBorderWidth" format="dimension" />
+        <attr name="selectedBorderColor" format="color" />
+        <attr name="selectedBorderDashWidth" format="dimension" />
+        <attr name="selectedBorderDashGap" format="dimension" />
+
         <attr name="radius" format="dimension" />
         <attr name="selectedButtonRadius" format="dimension" />
         <attr name="position" format="integer" />

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -47,6 +47,7 @@
         <attr name="borderDashGap" format="dimension" />
 
         <attr name="radius" format="dimension" />
+        <attr name="selectedButtonRadius" format="dimension" />
         <attr name="position" format="integer" />
         <attr name="draggable" format="boolean" />
         <attr name="android:clickable" />

--- a/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
+++ b/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
@@ -50,7 +50,10 @@ enum Action {
     ChangeText,
     ChangeTextColor,
     ChangeTextSize,
-    ChangeTypeface;
+    ChangeTypeface,
+    ChangeSelectedButtonRadius,
+    ChangeSelectedButtonBorderSolid,
+    ChangeSelectedButtonBorderDashed;
 
     public String getDisplayText() {
         if (this == None) {
@@ -97,6 +100,12 @@ enum Action {
             return "Change text size";
         } else if (this == ChangeTypeface) {
             return "Change typeface";
+        } else if (this == ChangeSelectedButtonRadius) {
+            return "Change selected button radius";
+        } else if (this == ChangeSelectedButtonBorderSolid) {
+            return "Change selected button border (solid)";
+        } else if (this == ChangeSelectedButtonBorderDashed) {
+            return "Change selected button border (dashed)";
         } else {
             return "";
         }
@@ -137,6 +146,8 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
     SegmentedButtonGroup pickupDropoffButtonGroup;
     @BindView(R.id.buttonGroup_starWarsAlt)
     SegmentedButtonGroup starWarsAltButtonGroup;
+    @BindView(R.id.buttonGroup_roundSelectedButton)
+    SegmentedButtonGroup roundSelectedButtonGroup;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -315,6 +326,25 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
 
             case ChangeTypeface:
                 lordOfTheRingsButtonGroup.getButton(0).setTextTypeface(Typeface.create((Typeface) null, Typeface.BOLD));
+                break;
+
+            case ChangeSelectedButtonRadius: {
+                final float radius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30.0f,
+                        getApplicationContext().getResources().getDisplayMetrics());
+
+                lordOfTheRingsButtonGroup.setSelectedButtonRadius((int)radius);
+                roundSelectedButtonGroup.setSelectedButtonRadius(0);
+            }
+            break;
+
+            case ChangeSelectedButtonBorderSolid:
+                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 0, 0);
+                roundSelectedButtonGroup.setSelectedBorder(0, 0, 0, 0);
+                break;
+
+            case ChangeSelectedButtonBorderDashed:
+                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 6, 3);
+                roundSelectedButtonGroup.setSelectedBorder(16, Color.BLACK, 6, 2);
                 break;
 
             default:

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -340,6 +340,7 @@
             app:position="2"
             app:radius="2dp"
             app:rippleColor="@color/white"
+            app:selectedButtonRadius="32dp"
             app:selectedBackground="@color/white"
             app:selectionAnimationDuration="1000"
             app:selectionAnimationInterpolator="fastOutSlowIn">

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -43,8 +43,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                android:elevation="2dp"
                 app:background="@drawable/gradient_drawable"
+                android:elevation="2dp"
                 app:divider="@drawable/gradient_drawable_divider"
                 app:dividerPadding="10dp"
                 app:dividerRadius="10dp"
@@ -87,6 +87,7 @@
 
         </LinearLayout>
 
+        <!--            app:background="@color/white"-->
         <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
             android:id="@+id/buttonGroup_lordOfTheRings"
             android:layout_width="match_parent"
@@ -94,7 +95,7 @@
             android:layout_gravity="center_horizontal"
             android:layout_margin="4dp"
             android:elevation="2dp"
-            app:background="@color/white"
+            app:background="@drawable/gradient_drawable"
             app:borderColor="@color/orange_700"
             app:borderWidth="1dp"
             app:divider="@color/orange_700"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -330,6 +330,7 @@
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
+        <!--TODO Remove me and make a proper test-->
         <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
             android:id="@+id/buttonGroup_darthVader"
             android:layout_width="match_parent"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -43,8 +43,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
-                app:background="@drawable/gradient_drawable"
                 android:elevation="2dp"
+                app:background="@drawable/gradient_drawable"
                 app:divider="@drawable/gradient_drawable_divider"
                 app:dividerPadding="10dp"
                 app:dividerRadius="10dp"
@@ -87,7 +87,6 @@
 
         </LinearLayout>
 
-        <!--            app:background="@color/white"-->
         <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
             android:id="@+id/buttonGroup_lordOfTheRings"
             android:layout_width="match_parent"
@@ -95,7 +94,7 @@
             android:layout_gravity="center_horizontal"
             android:layout_margin="4dp"
             android:elevation="2dp"
-            app:background="@drawable/gradient_drawable"
+            app:background="@color/white"
             app:borderColor="@color/orange_700"
             app:borderWidth="1dp"
             app:divider="@color/orange_700"
@@ -475,9 +474,9 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
+                android:padding="8dp"
                 app:drawableGravity="right"
                 app:drawablePadding="8dp"
-                android:padding="8dp"
                 app:drawableTint="@color/white"
                 app:selectedDrawableTint="@color/black"
                 app:text="Left" />

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -342,6 +342,8 @@
             app:radius="2dp"
             app:rippleColor="@color/white"
             app:selectedButtonRadius="32dp"
+            app:selectedBorderWidth="2dp"
+            app:selectedBorderColor="@color/red"
             app:selectedBackground="@color/white"
             app:selectionAnimationDuration="1000"
             app:selectionAnimationInterpolator="fastOutSlowIn">

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -330,7 +330,6 @@
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
 
-        <!--TODO Remove me and make a proper test-->
         <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
             android:id="@+id/buttonGroup_darthVader"
             android:layout_width="match_parent"
@@ -341,9 +340,6 @@
             app:position="2"
             app:radius="2dp"
             app:rippleColor="@color/white"
-            app:selectedButtonRadius="32dp"
-            app:selectedBorderWidth="2dp"
-            app:selectedBorderColor="@color/red"
             app:selectedBackground="@color/white"
             app:selectionAnimationDuration="1000"
             app:selectionAnimationInterpolator="fastOutSlowIn">
@@ -580,6 +576,57 @@
                 android:paddingBottom="6dp"
                 android:paddingTop="6dp"
                 app:drawable="@drawable/ic_b11" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_roundSelectedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            app:background="@color/white"
+            app:position="0"
+            app:radius="30dp"
+            app:rippleColor="@color/black"
+            app:selectedBackground="@color/blue_500"
+            app:selectedBorderColor="#555555"
+            app:selectedBorderWidth="2dp"
+            app:selectedButtonRadius="30dp"
+            app:selectionAnimationDuration="1000">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="Yes"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="Maybe"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="No"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
 
         </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
     </LinearLayout>


### PR DESCRIPTION
# Changes
* Implement selected button radius parameter to round corners of selected button
* Implement selected button border parameter to add border to selected button (this factors in the button radius too)
* Overhaul the way rounded corners are rendered for the background, selected background and even the selected button radius. I discovered a noticeable issue where the rounded corners were not antialiased using Canvas.clipPath. This was solved via switching to creating bitmaps from the drawables and using a bitmap shader. This has the effect of removing jagged looking edges for the rounded corners.
* Revert draggable fix using touch slop

Fixes issue #4 