### PR TITLE
Fix missing layout preview & clean up README (#14, #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This project is originally forked from [ceryle/SegmentedButton](https://github.c
 [![10](https://www.addisonelliott.net/SegmentedButtonImages/LeftRight.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L459)
 [![11](https://www.addisonelliott.net/SegmentedButtonImages/PickupDropoff.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L498)
 
+Code for all images can be found in the [sample project](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml)
+
 ## Installation
 
 #### Gradle

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 | ------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
 | android:background              | `drawable\|color` | Set background for button when unselected (default: transparent)             |
 | app:selectedBackground          | `drawable\|color` | Set background for button when selected (default: transparent)               |
-| app:rounded                     | `boolean`         | Whether or not the button is rounded. Note: This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
+| app:rounded                     | `boolean`         | Whether or not the button is rounded. **Note:** This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
 | app:rippleColor                 | `color`           | Ripple effect tint color when user taps on button                            |
 | app:drawable                    | `drawable`        | Drawable to display                                                          |
 | app:drawablePadding             | `dimension`       | Padding between drawable and text                                            |

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ This project is originally forked from [ceryle/SegmentedButton](https://github.c
 
 ## Preview
 
-![1](https://www.addisonelliott.net/SegmentedButtonImages/Gradient.gif)
-![2](https://www.addisonelliott.net/SegmentedButtonImages/LordOfTheRings.gif)
-![3](https://www.addisonelliott.net/SegmentedButtonImages/DCSuperheros.gif)
-![4](https://www.addisonelliott.net/SegmentedButtonImages/MarvelSuperheros.gif)
-![5](https://www.addisonelliott.net/SegmentedButtonImages/Guys.gif)
-![6](https://www.addisonelliott.net/SegmentedButtonImages/StarWars.gif)
-![7](https://www.addisonelliott.net/SegmentedButtonImages/DarthVader.gif)
-![8](https://www.addisonelliott.net/SegmentedButtonImages/YesNoMaybe.gif)
-![9](https://www.addisonelliott.net/SegmentedButtonImages/YesNoMaybeRound.gif)
-![10](https://www.addisonelliott.net/SegmentedButtonImages/LeftRight.gif)
-![11](https://www.addisonelliott.net/SegmentedButtonImages/PickupDropoff.gif)
+[![1](https://www.addisonelliott.net/SegmentedButtonImages/Gradient.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L26)
+[![2](https://www.addisonelliott.net/SegmentedButtonImages/LordOfTheRings.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L91)
+[![3](https://www.addisonelliott.net/SegmentedButtonImages/DCSuperheros.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L147)
+[![4](https://www.addisonelliott.net/SegmentedButtonImages/MarvelSuperheros.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L216)
+[![5](https://www.addisonelliott.net/SegmentedButtonImages/Guys.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L253)
+[![6](https://www.addisonelliott.net/SegmentedButtonImages/StarWars.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L285)
+[![7](https://www.addisonelliott.net/SegmentedButtonImages/DarthVader.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L334)
+[![8](https://www.addisonelliott.net/SegmentedButtonImages/YesNoMaybe.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L399)
+[![9](https://www.addisonelliott.net/SegmentedButtonImages/YesNoMaybeRound.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L583)
+[![10](https://www.addisonelliott.net/SegmentedButtonImages/LeftRight.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L459)
+[![11](https://www.addisonelliott.net/SegmentedButtonImages/PickupDropoff.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L498)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project is originally forked from [ceryle/SegmentedButton](https://github.c
 [![9](https://www.addisonelliott.net/SegmentedButtonImages/YesNoMaybeRound.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L583)
 [![10](https://www.addisonelliott.net/SegmentedButtonImages/LeftRight.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L459)
 [![11](https://www.addisonelliott.net/SegmentedButtonImages/PickupDropoff.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L498)
+[![12](https://www.addisonelliott.net/SegmentedButtonImages/RoundedTransparentButtons.gif)](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml#L634)
 
 Code for all images can be found in the [sample project](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml)
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 | ------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
 | android:background              | `drawable\|color` | Set background for button when unselected (default: transparent)             |
 | app:selectedBackground          | `drawable\|color` | Set background for button when selected (default: transparent)               |
-| app:rounded                     | `boolean`         | Whether or not the button is rounded. **Note:** This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
+| app:rounded                     | `boolean`         | Whether or not the button is rounded.<br />**Note:** This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
 | app:rippleColor                 | `color`           | Ripple effect tint color when user taps on button                            |
 | app:drawable                    | `drawable`        | Drawable to display                                                          |
 | app:drawablePadding             | `dimension`       | Padding between drawable and text                                            |

--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 | ------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
 | android:background              | `drawable\|color` | Set background for button when unselected (default: transparent)             |
 | app:selectedBackground          | `drawable\|color` | Set background for button when selected (default: transparent)               |
-| app:rounded                     | `boolean`         | Whether or not the button is rounded. Note: This is used to round **BOTH** 
-sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
+| app:rounded                     | `boolean`         | Whether or not the button is rounded. Note: This is used to round **BOTH** sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
 | app:rippleColor                 | `color`           | Ripple effect tint color when user taps on button                            |
 | app:drawable                    | `drawable`        | Drawable to display                                                          |
 | app:drawablePadding             | `dimension`       | Padding between drawable and text                                            |
@@ -192,8 +191,7 @@ sides of a button. The typical use case is for rounded buttons with a transparen
 | app:selectedDrawableTint        | `color`           | Tint color for drawable when selected                                        |
 | app:drawableWidth               | `dimension`       | Width of drawable (default uses intrinsic)                                   |
 | app:drawableHeight              | `dimension`       | Height of drawable (default uses intrinsic)                                  |
-| app:drawableGravity             | `enum`            | Determines where drawable should be placed in relation to the text. Valid 
-options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                                                     |
+| app:drawableGravity             | `enum`            | Determines where drawable should be placed in relation to the text. Valid options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                                                     |
 | app:text                        | `string`          | Text to display on button                                                    |
 | app:textColor                   | `color`           | Color of text when button is unselected                                      |
 | app:selectedTextColor           | `color`           | Color of text when button is selected                                        |

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ latest features & bug fixes.
 **Note:** Java 8 is required to use this library. This can be done by adding the following code to `build.gradle` while
 using the Android plugin with a version of `3.0.0` or higher.
 
-```
+```gradle
 android {
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
     }
 }
 ```
@@ -146,14 +146,16 @@ segmentedButtonGroup.setOnPositionChangedListener(new OnPositionChangedListener(
 segmentedButtonGroup.getPosition();
 ```
 
+Check out the [sample project](https://github.com/addisonElliott/SegmentedButton/blob/master/sample/src/main/res/layout/activity_main.xml) for additional examples
+
 ## Attributes
 
 ### SegmentedButtonGroup
 
 | Attribute                          | Format            | Description                                                                |
 | ---------------------------------- | ----------------- | -------------------------------------------------------------------------- |
-| android:background                 | `drawable\|color` | Set background for every button when unselected                            |
-| app:selectedBackground             | `drawable\|color` | Set background for every button when selected                              |
+| android:background                 | `drawable\|color` | Set background for every button when unselected (default: transparent)     |
+| app:selectedBackground             | `drawable\|color` | Set background for every button when selected (default: transparent)       |
 | app:borderWidth                    | `dimension`       | Width of border around button group                                        |
 | app:borderColor                    | `color`           | Color of border                                                            |
 | app:borderDashWidth                | `dimension`       | Width of dashes, 0 indicates solid line                                    |
@@ -179,9 +181,10 @@ segmentedButtonGroup.getPosition();
 
 | Option Name                     | Format            | Description                                                                  |
 | ------------------------------- | ----------------- | ---------------------------------------------------------------------------- |
-| android:background              | `drawable\|color` | Set background for button when unselected                                    |
-| app:selectedBackground          | `drawable\|color` | Set background for button when selected                                      |
-| app:rounded                     | `boolean`         | Whether or not the button is rounded                                         |
+| android:background              | `drawable\|color` | Set background for button when unselected (default: transparent)             |
+| app:selectedBackground          | `drawable\|color` | Set background for button when selected (default: transparent)               |
+| app:rounded                     | `boolean`         | Whether or not the button is rounded. Note: This is used to round **BOTH** 
+sides of a button. The typical use case is for rounded buttons with a transparent background.                                        |
 | app:rippleColor                 | `color`           | Ripple effect tint color when user taps on button                            |
 | app:drawable                    | `drawable`        | Drawable to display                                                          |
 | app:drawablePadding             | `dimension`       | Padding between drawable and text                                            |
@@ -189,7 +192,8 @@ segmentedButtonGroup.getPosition();
 | app:selectedDrawableTint        | `color`           | Tint color for drawable when selected                                        |
 | app:drawableWidth               | `dimension`       | Width of drawable (default uses intrinsic)                                   |
 | app:drawableHeight              | `dimension`       | Height of drawable (default uses intrinsic)                                  |
-| app:drawableGravity             | `enum`            | Determines where drawable should be placed in relation to the text. Valid options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                                                     |
+| app:drawableGravity             | `enum`            | Determines where drawable should be placed in relation to the text. Valid 
+options are `Gravity.LEFT`, `Gravity.TOP`, `Gravity.RIGHT`, and `Gravity.BOTTOM`                                                     |
 | app:text                        | `string`          | Text to display on button                                                    |
 | app:textColor                   | `color`           | Color of text when button is unselected                                      |
 | app:selectedTextColor           | `color`           | Color of text when button is selected                                        |

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ ext {
     minSdkVersion = 16
     compileSdkVersion = 28
     buildToolsVersion = '28.0.3'
-    androidXLibraryVersion = '1.0.2'
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 03 17:03:56 CST 2019
+#Sat Jul 13 20:01:16 CDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,8 +24,8 @@ android {
     // Configure only for each module that uses Java 8 language features (either in its source code or through
     // dependencies).
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
     }
 }
 
@@ -54,10 +54,10 @@ artifacts {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13-beta-3'
 
-    implementation "androidx.appcompat:appcompat:$androidXLibraryVersion"
+    implementation "androidx.appcompat:appcompat:1.0.2"
     implementation "androidx.interpolator:interpolator:1.0.0"
-    implementation "androidx.core:core:1.0.1"
+    implementation "androidx.core:core:1.0.2"
     api 'com.github.addisonElliott:RippleDrawable:3.0.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -59,5 +59,5 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidXLibraryVersion"
     implementation "androidx.interpolator:interpolator:1.0.0"
     implementation "androidx.core:core:1.0.1"
-    implementation 'com.github.addisonElliott:RippleDrawable:3.0.0'
+    api 'com.github.addisonElliott:RippleDrawable:3.0.0'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,18 +22,18 @@ android {
     // Configure only for each module that uses Java 8 language features (either in its source code or through
     // dependencies).
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
     }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "androidx.appcompat:appcompat:$androidXLibraryVersion"
+    implementation "androidx.appcompat:appcompat:1.0.2"
 
-    implementation 'com.jakewharton:butterknife:10.0.0'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:10.0.0'
+    implementation 'com.jakewharton:butterknife:10.1.0'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
 
     api project(":library")
 }

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Base.Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
Fix odd bug with Android Studio not showing layout preview due to RippleDrawable library.

Add rounded button GIF to README and update `rounded` property description to further detail it's purpose.