### PR TITLE
Divider rehaul w/ bug fixes & text size bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
     }

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/ButtonActor.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/ButtonActor.java
@@ -1,0 +1,92 @@
+package com.addisonelliott.segmentedbutton;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import androidx.annotation.Nullable;
+
+/**
+ * Empty, transparent view used as a "dummy" or filler view
+ *
+ * This view is used as spacers for the SegmentedButtonGroup LinearLayout that handles the dividers
+ *
+ * Each view has a model SegmentedButton that it mimics the width & height of. The width & height is adjusted for the
+ * divider width to appropriate position the dividers in between the two buttons.
+ */
+class ButtonActor extends View
+{
+    // Button to mimics size of
+    private SegmentedButton button = null;
+
+    // Divider width
+    private int dividerWidth = 0;
+
+    public ButtonActor(Context context)
+    {
+        super(context);
+    }
+
+    public ButtonActor(Context context, @Nullable AttributeSet attrs)
+    {
+        super(context, attrs);
+    }
+
+    public ButtonActor(Context context, @Nullable AttributeSet attrs, int defStyleAttr)
+    {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public void setButton(SegmentedButton button)
+    {
+        this.button = button;
+    }
+
+    public void setDividerWidth(int width)
+    {
+        dividerWidth = width;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
+    {
+        // Desired size is the suggested minimum size
+        // Resolve size based on the measure spec and go from there
+        // resolveSize
+        // View.onMeasure uses getDefaultSize which is similar to resolveSize except in the case of
+        // MeasureSpec.AT_MOST, the maximum value will be returned. In other words, View will expand to fill the
+        // available area while resolveSize will only use the desired size.
+
+        // Width and height to set the view to
+        int width;
+        int height;
+
+        if (button != null)
+        {
+            // Calculate the amount to offset the model buttons parent width by
+            //
+            // (dividerWidth / 2) is subtracted from the width for each divider present
+            // Buttons with neighboring buttons on both sides, this adds up to dividerWidth
+            // Left-most and right-most buttons only have one divider, so this is (dividerWidth / 2)
+            // And if there is EXACTLY one button being shown, no dividers are present and so the offset is 0
+            int widthOffset;
+            if (button.isLeftButton() && button.isRightButton())
+                widthOffset = 0;
+            else if (button.isLeftButton() || button.isRightButton())
+                widthOffset = dividerWidth / 2;
+            else
+                widthOffset = dividerWidth;
+
+            // Calculate the width & height based on the desired width & height and the measure specs
+            width = resolveSize(button.getMeasuredWidth() - widthOffset, widthMeasureSpec);
+            height = resolveSize(button.getMeasuredHeight(), heightMeasureSpec);
+        }
+        else
+        {
+            // Fallback option to calculate the size based on suggested minimum width & height
+            width = resolveSize(getSuggestedMinimumWidth(), widthMeasureSpec);
+            height = resolveSize(getSuggestedMinimumHeight(), heightMeasureSpec);
+        }
+
+        setMeasuredDimension(width, height);
+    }
+}

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/EmptyView.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/EmptyView.java
@@ -53,22 +53,26 @@ import androidx.annotation.Nullable;
  * For the case of getDefaultSize for View, AT_MOST will return the maximum value but resolveSize will return UP TO
  * the max size, but it will prefer the desired value.
  */
-class EmptyView extends View {
-
-    public EmptyView(Context context) {
+class EmptyView extends View
+{
+    public EmptyView(Context context)
+    {
         super(context);
     }
 
-    public EmptyView(Context context, @Nullable AttributeSet attrs) {
+    public EmptyView(Context context, @Nullable AttributeSet attrs)
+    {
         super(context, attrs);
     }
 
-    public EmptyView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    public EmptyView(Context context, @Nullable AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
     }
 
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
+    {
         // Desired size is the suggested minimum size
         // Resolve size based on the measure spec and go from there
         // resolveSize

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/EmptyView.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/EmptyView.java
@@ -6,7 +6,7 @@ import android.view.View;
 import androidx.annotation.Nullable;
 
 /**
- * Empty, transparent view useful as a "dummy" or filler view
+ * Empty, transparent view used as a "dummy" or filler view
  *
  * This view has a desired size of (minimumWidth, minimumHeight) but will not expand past this size if the space is
  * available. This is contrary to View's implementation, which will expand to fill the available space.
@@ -53,26 +53,22 @@ import androidx.annotation.Nullable;
  * For the case of getDefaultSize for View, AT_MOST will return the maximum value but resolveSize will return UP TO
  * the max size, but it will prefer the desired value.
  */
-class EmptyView extends View
-{
-    public EmptyView(Context context)
-    {
+class EmptyView extends View {
+
+    public EmptyView(Context context) {
         super(context);
     }
 
-    public EmptyView(Context context, @Nullable AttributeSet attrs)
-    {
+    public EmptyView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public EmptyView(Context context, @Nullable AttributeSet attrs, int defStyleAttr)
-    {
+    public EmptyView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
-    {
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // Desired size is the suggested minimum size
         // Resolve size based on the measure spec and go from there
         // resolveSize

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -51,8 +51,8 @@ import java.lang.annotation.RetentionPolicy;
 
 @SuppressWarnings("unused")
 @SuppressLint("RtlHardcoded")
-public class SegmentedButton extends View {
-
+public class SegmentedButton extends View
+{
     // region Variables & Constants
     private static final String TAG = "SegmentedButton";
 
@@ -180,25 +180,29 @@ public class SegmentedButton extends View {
 
     // region Constructor
 
-    public SegmentedButton(Context context) {
+    public SegmentedButton(Context context)
+    {
         super(context);
 
         init(context, null);
     }
 
-    public SegmentedButton(Context context, AttributeSet attrs) {
+    public SegmentedButton(Context context, AttributeSet attrs)
+    {
         super(context, attrs);
 
         init(context, attrs);
     }
 
-    public SegmentedButton(Context context, AttributeSet attrs, int defStyleAttr) {
+    public SegmentedButton(Context context, AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
 
         init(context, attrs);
     }
 
-    private void init(Context context, @Nullable AttributeSet attrs) {
+    private void init(Context context, @Nullable AttributeSet attrs)
+    {
         // Retrieve custom attributes
         getAttributes(context, attrs);
 
@@ -226,7 +230,8 @@ public class SegmentedButton extends View {
         setClickable(true);
     }
 
-    private void getAttributes(Context context, @Nullable AttributeSet attrs) {
+    private void getAttributes(Context context, @Nullable AttributeSet attrs)
+    {
         // According to docs for obtainStyledAttributes, attrs can be null and I assume that each value will be set
         // to the default
         TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.SegmentedButton);
@@ -234,14 +239,12 @@ public class SegmentedButton extends View {
         // Load background if available, this can be a drawable or a color
         // In the instance of a color, a ColorDrawable is created and used instead
         // Note: Not well documented but getDrawable will return a ColorDrawable if a color is specified
-        if (ta.hasValue(R.styleable.SegmentedButton_android_background)) {
+        if (ta.hasValue(R.styleable.SegmentedButton_android_background))
             backgroundDrawable = ta.getDrawable(R.styleable.SegmentedButton_android_background);
-        }
 
         // Load background on selection if available, can be drawable or color
-        if (ta.hasValue(R.styleable.SegmentedButton_selectedBackground)) {
+        if (ta.hasValue(R.styleable.SegmentedButton_selectedBackground))
             selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButton_selectedBackground);
-        }
 
         rounded = ta.getBoolean(R.styleable.SegmentedButton_rounded, false);
 
@@ -249,7 +252,8 @@ public class SegmentedButton extends View {
         setRipple(ta.getColor(R.styleable.SegmentedButton_rippleColor, Color.GRAY));
 
         // Load drawable if available, otherwise variable will be null
-        if (ta.hasValue(R.styleable.SegmentedButton_drawable)) {
+        if (ta.hasValue(R.styleable.SegmentedButton_drawable))
+        {
             int drawableResId = ta.getResourceId(R.styleable.SegmentedButton_drawable, -1);
             drawable = readCompatDrawable(context, drawableResId);
         }
@@ -279,38 +283,49 @@ public class SegmentedButton extends View {
         final int textStyle = ta.getInt(R.styleable.SegmentedButton_textStyle, Typeface.NORMAL);
 
         // If a font family is present then load typeface with text style from that
-        if (hasFontFamily) {
+        if (hasFontFamily)
+        {
             // Note: TypedArray.getFont is used for Android O & above while ResourcesCompat.getFont is used for below
             // Experienced an odd bug in the design viewer of Android Studio where it would not work with only using
             // the ResourcesCompat.getFont function. Unsure of the reason but this fixes it
-            if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            if (VERSION.SDK_INT >= VERSION_CODES.O)
+            {
                 textTypeface = Typeface.create(ta.getFont(R.styleable.SegmentedButton_android_fontFamily), textStyle);
-            } else {
+            }
+            else
+            {
                 final int fontFamily = ta.getResourceId(R.styleable.SegmentedButton_android_fontFamily, 0);
 
-                if (fontFamily > 0) {
+                if (fontFamily > 0)
+                {
                     textTypeface = Typeface.create(ResourcesCompat.getFont(context, fontFamily), textStyle);
-                } else {
+                }
+                else
+                {
                     // On lower API Android versions, fontFamily returns 0 for default fonts such as "sans-serif" and
                     // "monospace". Thus, we get the font as a string and then try to load that way
                     textTypeface = Typeface.create(ta.getString(R.styleable.SegmentedButton_android_fontFamily),
                             textStyle);
                 }
             }
-        } else {
-            textTypeface = Typeface.create((Typeface) null, textStyle);
+        }
+        else
+        {
+            textTypeface = Typeface.create((Typeface)null, textStyle);
         }
 
         ta.recycle();
     }
 
-    private void initText() {
+    private void initText()
+    {
         // Text position is calculated regardless of if text exists
         // Not worth extra effort of not setting two float values
         textPosition = new PointF();
 
         // If there is no text then do not bother
-        if (!hasText) {
+        if (!hasText)
+        {
             textStaticLayout = null;
             return;
         }
@@ -323,49 +338,53 @@ public class SegmentedButton extends View {
         textPaint.setTypeface(textTypeface);
 
         // Initial kickstart to setup the text layout by assuming the text will be all in one line
-        textMaxWidth = (int) textPaint.measureText(text);
-        if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {
+        textMaxWidth = (int)textPaint.measureText(text);
+        Log.v(TAG, String.format("initText called(%s): %d", text, textMaxWidth));
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.M)
+        {
             textStaticLayout = StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, textMaxWidth).build();
-        } else {
+        }
+        else
+        {
             textStaticLayout = new StaticLayout(text, textPaint, textMaxWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0,
                     false);
         }
     }
 
-    private Drawable readCompatDrawable(Context context, int drawableResId) {
+    private Drawable readCompatDrawable(Context context, int drawableResId)
+    {
         Drawable drawable = AppCompatResources.getDrawable(context, drawableResId);
 
         // API 28 has a bug with vector drawables where the selected tint color is always applied to the drawable
         // To prevent this, the vector drawable is converted to a bitmap
         if ((VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && drawable instanceof VectorDrawable)
-                || drawable instanceof VectorDrawableCompat) {
+                || drawable instanceof VectorDrawableCompat)
+        {
             Bitmap bitmap = getBitmapFromVectorDrawable(drawable);
             return new BitmapDrawable(context.getResources(), bitmap);
-        } else {
-            return drawable;
         }
+        else
+            return drawable;
     }
 
 
-    private void initDrawable() {
+    private void initDrawable()
+    {
         // Drawable position is calculated regardless of if drawable exists
         // Not worth extra effort of not setting two float values
         drawablePosition = new PointF();
 
         // If there is no drawable then do not bother
-        if (drawable == null) {
+        if (drawable == null)
             return;
-        }
 
         // If drawable has a tint color, then create a color filter that will be applied to it
-        if (hasDrawableTint) {
+        if (hasDrawableTint)
             drawableColorFilter = new PorterDuffColorFilter(drawableTint, PorterDuff.Mode.SRC_IN);
-        }
 
         // If selected drawable has a tint color, then create a color filter that will be applied to it
-        if (hasSelectedDrawableTint) {
+        if (hasSelectedDrawableTint)
             selectedDrawableColorFilter = new PorterDuffColorFilter(selectedDrawableTint, PorterDuff.Mode.SRC_IN);
-        }
     }
 
     // endregion
@@ -374,7 +393,8 @@ public class SegmentedButton extends View {
 
     @SuppressLint("DrawAllocation")
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec)
+    {
         // Measured width & height
         int width, height;
 
@@ -389,11 +409,14 @@ public class SegmentedButton extends View {
         // drawable and text.
         int desiredWidth = getPaddingLeft() + getPaddingRight();
 
-        if (Gravity.isHorizontal(drawableGravity)) {
+        if (Gravity.isHorizontal(drawableGravity))
+        {
             // When drawable and text are inline horizontally, then the total desired width is:
             //     padding left + text width (assume one line) + drawable padding + drawable width + padding right
             desiredWidth += textWidth + drawablePadding + drawableWidth;
-        } else {
+        }
+        else
+        {
             // When drawable and text are on top of each other, the total desired width is:
             //     padding left + max(text width, drawable width) + padding right
             desiredWidth += Math.max(textWidth, drawableWidth);
@@ -418,11 +441,14 @@ public class SegmentedButton extends View {
 
         int desiredHeight = getPaddingTop() + getPaddingBottom();
 
-        if (Gravity.isHorizontal(drawableGravity)) {
+        if (Gravity.isHorizontal(drawableGravity))
+        {
             // When drawable and text are horizontal, the total desired height is:
             //     padding left + max(text width, drawable width) + padding right
             desiredHeight += Math.max(textHeight, drawableHeight);
-        } else {
+        }
+        else
+        {
             // When drawable and text are vertical, then the total desired height is:
             //     padding left + text width (assume one line) + drawable padding + drawable width + padding right
             desiredHeight += textHeight + drawablePadding + drawableHeight;
@@ -435,16 +461,24 @@ public class SegmentedButton extends View {
         //      - MeasureSpec.UNSPECIFIED: Set height to desired size
         height = resolveSize(desiredHeight, heightMeasureSpec);
 
+        Log.v(TAG, String.format("onMeasure called(%s): %d %d", text, widthMeasureSpec, heightMeasureSpec));
+        Log.v(TAG, String.format("Desired width: %d Width: %d", desiredWidth, width));
+        Log.v(TAG, String.format("Desired height: %d Height: %d", desiredHeight, height));
+        Log.v(TAG, String.format("Text info: %d %d %d", textMaxWidth, getPaddingTop(), getPaddingRight()));
+
         // Required to be called to notify the View of the width & height decided
         setMeasuredDimension(width, height);
     }
 
     @Override
-    protected void onSizeChanged(final int w, final int h, final int oldw, final int oldh) {
+    protected void onSizeChanged(final int w, final int h, final int oldw, final int oldh)
+    {
         super.onSizeChanged(w, h, oldw, oldh);
 
         // Calculate new positions and bounds for text & drawable
         updateSize();
+
+        Log.v(TAG, String.format("onSizeChanged(%s): %d %d %d %d", text, w, h, oldw, oldh));
 
         // Recalculate the background clip path since width & height have changed
         setupBackgroundClipPath();
@@ -459,11 +493,11 @@ public class SegmentedButton extends View {
      * @param width         size, in pixels, of the button
      * @param drawableWidth size, in pixels, of the drawable
      */
-    private void measureTextWidth(int width, int drawableWidth) {
+    private void measureTextWidth(int width, int drawableWidth)
+    {
         // If there is no text, then we don't need to do anything
-        if (!hasText) {
+        if (!hasText)
             return;
-        }
 
         // Set drawable width to be the drawable width if the drawable has horizontal gravity, otherwise the drawable
         // width doesnt matter
@@ -473,16 +507,18 @@ public class SegmentedButton extends View {
         int textWidth = Math.min(width - getPaddingLeft() - getPaddingRight() - newDrawableWidth, textMaxWidth);
 
         // Odd case where there is not enough space for the padding and drawable width so we just return
-        if (textWidth < 0) {
+        if (textWidth < 0)
             return;
-        }
 
         // Create new static layout with width
         // Old way of creating static layout was deprecated but I dont think there is any speed difference between
         // the two
-        if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.M)
+        {
             textStaticLayout = StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, textWidth).build();
-        } else {
+        }
+        else
+        {
             textStaticLayout = new StaticLayout(text, textPaint, textWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0,
                     false);
         }
@@ -493,7 +529,8 @@ public class SegmentedButton extends View {
      *
      * This will be called on onSizeChanged, which is called less frequently than onMeasure which will speed things up
      */
-    private void updateSize() {
+    private void updateSize()
+    {
         final int width = getWidth(), height = getHeight();
         final int textWidth = hasText ? textStaticLayout.getWidth() : 0;
         final int textHeight = hasText ? textStaticLayout.getHeight() : 0;
@@ -503,7 +540,8 @@ public class SegmentedButton extends View {
                 : drawable.getIntrinsicHeight() : 0;
 
         // Calculates the X/Y positions of the text and drawable now that the measured size is known
-        if (Gravity.isHorizontal(drawableGravity)) {
+        if (Gravity.isHorizontal(drawableGravity))
+        {
             // Calculate Y position for horizontal gravity, i.e. center the drawable and/or text if necessary
             textPosition.y = getPaddingTop()
                     + (height - getPaddingTop() - getPaddingBottom() - textHeight) / 2.0f;
@@ -515,14 +553,19 @@ public class SegmentedButton extends View {
             final float startPosition = (width - textWidth - drawableWidth - drawablePadding) / 2.0f;
 
             // Position the drawable & text based on the gravity
-            if (drawableGravity == Gravity.LEFT) {
+            if (drawableGravity == Gravity.LEFT)
+            {
                 textPosition.x = startPosition + drawableWidth + drawablePadding;
                 drawablePosition.x = startPosition;
-            } else if (drawableGravity == Gravity.RIGHT) {
+            }
+            else if (drawableGravity == Gravity.RIGHT)
+            {
                 textPosition.x = startPosition;
                 drawablePosition.x = startPosition + textWidth + drawablePadding;
             }
-        } else {
+        }
+        else
+        {
             // Calculate X position for vertical gravity, i.e. center the drawable and/or text horizontally if necessary
             textPosition.x = getPaddingLeft()
                     + (width - getPaddingLeft() - getPaddingRight() - textWidth) / 2.0f;
@@ -534,40 +577,40 @@ public class SegmentedButton extends View {
             final float startPosition = (height - textHeight - drawableHeight - drawablePadding) / 2.0f;
 
             // Position the drawable & text based on the gravity
-            if (drawableGravity == Gravity.TOP) {
+            if (drawableGravity == Gravity.TOP)
+            {
                 textPosition.y = startPosition + drawableHeight + drawablePadding;
                 drawablePosition.y = startPosition;
-            } else if (drawableGravity == Gravity.BOTTOM) {
+            }
+            else if (drawableGravity == Gravity.BOTTOM)
+            {
                 textPosition.y = startPosition;
                 drawablePosition.y = startPosition + textHeight + drawablePadding;
             }
         }
 
         // Set bounds of drawable if it exists
-        if (drawable != null) {
-            drawable.setBounds((int) drawablePosition.x, (int) drawablePosition.y,
-                    (int) drawablePosition.x + drawableWidth, (int) drawablePosition.y + drawableHeight);
+        if (drawable != null)
+        {
+            drawable.setBounds((int)drawablePosition.x, (int)drawablePosition.y,
+                    (int)drawablePosition.x + drawableWidth, (int)drawablePosition.y + drawableHeight);
         }
 
         // Set bounds of background drawable if it exists
-        if (backgroundDrawable != null) {
+        if (backgroundDrawable != null)
             backgroundDrawable.setBounds(0, 0, width, height);
-        }
 
         // Set bounds of selected background drawable if it exists
-        if (selectedBackgroundDrawable != null) {
+        if (selectedBackgroundDrawable != null)
             selectedBackgroundDrawable.setBounds(0, 0, width, height);
-        }
 
         // Set bounds of ripple drawable if it exists
-        if (rippleDrawableLollipop != null) {
+        if (rippleDrawableLollipop != null)
             rippleDrawableLollipop.setBounds(0, 0, width, height);
-        }
 
         // Set bounds of ripple drawable if it exists
-        if (rippleDrawable != null) {
+        if (rippleDrawable != null)
             rippleDrawable.setBounds(0, 0, width, height);
-        }
     }
 
     // endregion
@@ -575,14 +618,16 @@ public class SegmentedButton extends View {
     // region Drawing
 
     @Override
-    protected void onDraw(Canvas canvas) {
+    protected void onDraw(Canvas canvas)
+    {
         super.onDraw(canvas);
 
         final int width = getWidth();
         final int height = getHeight();
 
         // Draw background (unselected)
-        if (backgroundDrawable != null) {
+        if (backgroundDrawable != null)
+        {
             // Draw the background with rounded corners if the background clip path and background paint objet are
             // non-null. The background clip path will be present if the background has rounded corners. See
             // setupBackgroundClipPath for more details. Ideally the backgroundPaint object will always be present
@@ -590,15 +635,16 @@ public class SegmentedButton extends View {
             // the drawable because of unknown bounds on program start.
             //
             // Otherwise, the background is drawn normally via the drawable with no rounded corners
-            if (backgroundClipPath != null && backgroundPaint != null) {
+            if (backgroundClipPath != null && backgroundPaint != null)
                 canvas.drawPath(backgroundClipPath, backgroundPaint);
-            } else {
+            else
                 backgroundDrawable.draw(canvas);
-            }
         }
 
         // Draw text (unselected)
-        if (hasText) {
+        Log.v(TAG, String.format("onDraw called(%s)", text));
+        if (hasText)
+        {
             canvas.save();
             canvas.translate(textPosition.x, textPosition.y);
             textPaint.setColor(textColor);
@@ -607,7 +653,8 @@ public class SegmentedButton extends View {
         }
 
         // Draw drawable (unselected)
-        if (drawable != null) {
+        if (drawable != null)
+        {
             drawable.setColorFilter(drawableColorFilter);
             drawable.draw(canvas);
         }
@@ -625,7 +672,8 @@ public class SegmentedButton extends View {
         //
         // The amount of the left or right side being shown is based on the relativeClippingPosition, a value from
         // 0.0f to 1.0f representing the relative position on the button.
-        if (isClippingLeft) {
+        if (isClippingLeft)
+        {
             // If clipping the left, then relativeClipPosition * width represents the right side of the selected
             // button that is shown/clipped.
             //
@@ -644,7 +692,9 @@ public class SegmentedButton extends View {
             // doesn't matter.
             final float leftButtonWidth = isLeftButton() ? width : leftButton.getWidth();
             rectF.set((relativeClipPosition - 1.0f) * leftButtonWidth, 0.0f, relativeClipPosition * width, height);
-        } else {
+        }
+        else
+        {
             // Otherwise, if clipping the right, then the relativeClipPosition * width represents the left side of
             // the selected button that is shown/clipped.
             //
@@ -671,19 +721,25 @@ public class SegmentedButton extends View {
         //      2. Background has a radius (i.e. backgroundRadius > 0)
         // In these two cases, the background is drawn using a BitmapShader contained in the background paint object/
         // Otherwise, the background is drawn normally via the drawable with no rounded corners.
-        if (selectedButtonRadius > 0 && selectedBackgroundPaint != null) {
+        if (selectedButtonRadius > 0 && selectedBackgroundPaint != null)
+        {
             path.reset();
             path.addRoundRect(rectF, selectedButtonRadii, Direction.CW);
 
             canvas.drawPath(path, selectedBackgroundPaint);
-        } else if (backgroundClipPath != null && selectedBackgroundPaint != null) {
+        }
+        else if (backgroundClipPath != null && selectedBackgroundPaint != null)
+        {
             canvas.drawPath(backgroundClipPath, selectedBackgroundPaint);
-        } else if (selectedBackgroundDrawable != null) {
+        }
+        else if (selectedBackgroundDrawable != null)
+        {
             selectedBackgroundDrawable.draw(canvas);
         }
 
         // Draw text (selected)
-        if (hasText) {
+        if (hasText)
+        {
             canvas.save();
             canvas.translate(textPosition.x, textPosition.y);
             // If a selected text color was specified, then use that, otherwise we want to default to the original
@@ -694,7 +750,8 @@ public class SegmentedButton extends View {
         }
 
         // Draw drawable (selected)
-        if (drawable != null) {
+        if (drawable != null)
+        {
             // If a selected drawable tint was used, then use that, but if it wasn't specified we want to stick with
             // the normal tint color.
             drawable.setColorFilter(hasSelectedDrawableTint ? selectedDrawableColorFilter : drawableColorFilter);
@@ -702,7 +759,8 @@ public class SegmentedButton extends View {
         }
 
         // Draw a border around the selected button
-        if (selectedButtonBorderPaint != null) {
+        if (selectedButtonBorderPaint != null)
+        {
             // Get the border width from the paint information and divide by 2
             // Remember that rectF is the rectangle that was setup for the appropriate clip path above
             // Note that this rectangle should NOT be touched after the clip path is set otherwise the border drawn
@@ -729,17 +787,20 @@ public class SegmentedButton extends View {
 
         // Clip to the background clip path if available
         // This is used so the ripple effect will stop at the rounded corners of the background
-        if (backgroundClipPath != null) {
+        if (backgroundClipPath != null)
+        {
             canvas.clipPath(backgroundClipPath);
         }
 
         // Draw ripple drawable to show ripple effect on click
-        if (rippleDrawableLollipop != null) {
+        if (rippleDrawableLollipop != null)
+        {
             rippleDrawableLollipop.draw(canvas);
         }
 
         // Draw ripple drawable to show ripple effect on click
-        if (rippleDrawable != null) {
+        if (rippleDrawable != null)
+        {
             rippleDrawable.draw(canvas);
         }
 
@@ -761,7 +822,8 @@ public class SegmentedButton extends View {
      * @param relativePosition Position from 0.0f to 1.0f that represents where to end clipping. A value of 0.0f
      *                         would represent no clipping and 1.0f would represent clipping the entire view
      */
-    void clipLeft(@FloatRange(from = 0.0, to = 1.0) float relativePosition) {
+    void clipLeft(@FloatRange(from = 0.0, to = 1.0) float relativePosition)
+    {
         // Clipping from the left side, set to true
         isClippingLeft = true;
 
@@ -787,7 +849,8 @@ public class SegmentedButton extends View {
      * @param relativePosition Position from 0.0f to 1.0f that represents where to end clipping. A value of 1.0f
      *                         would represent no clipping and 0.0f would represent clipping the entire view
      */
-    void clipRight(@FloatRange(from = 0.0, to = 1.0) float relativePosition) {
+    void clipRight(@FloatRange(from = 0.0, to = 1.0) float relativePosition)
+    {
         // Clipping from the right side, set to false
         isClippingLeft = false;
 
@@ -817,13 +880,13 @@ public class SegmentedButton extends View {
      */
     @SuppressLint("NewApi")
     @Override
-    public void drawableHotspotChanged(final float x, final float y) {
+    public void drawableHotspotChanged(final float x, final float y)
+    {
         super.drawableHotspotChanged(x, y);
 
         // Update the hotspot for the ripple drawable
-        if (rippleDrawableLollipop != null) {
+        if (rippleDrawableLollipop != null)
             rippleDrawableLollipop.setHotspot(x, y);
-        }
     }
 
     /**
@@ -837,18 +900,17 @@ public class SegmentedButton extends View {
      * updated manually here since the base View class does not know about the ripple drawable.
      */
     @Override
-    protected void drawableStateChanged() {
+    protected void drawableStateChanged()
+    {
         super.drawableStateChanged();
 
         // Update the state for the ripple drawable
-        if (rippleDrawableLollipop != null) {
+        if (rippleDrawableLollipop != null)
             rippleDrawableLollipop.setState(getDrawableState());
-        }
 
         // Update the state for the ripple drawable
-        if (rippleDrawable != null) {
+        if (rippleDrawable != null)
             rippleDrawable.setState(getDrawableState());
-        }
     }
 
     /**
@@ -862,7 +924,8 @@ public class SegmentedButton extends View {
      * animate
      */
     @Override
-    protected boolean verifyDrawable(@NonNull final Drawable who) {
+    protected boolean verifyDrawable(@NonNull final Drawable who)
+    {
         // Very obscure and difficult to find but it is noted in the source code docstring for this function
         // Return true if the drawable is the ripple drawable (backport or regular)
         // Normally the super class handles this automatically for the background drawable but the ripple drawable is
@@ -887,7 +950,8 @@ public class SegmentedButton extends View {
      *
      * @param backgroundRadius radius of corners of parent button group in pixels
      */
-    void setBackgroundRadius(int backgroundRadius) {
+    void setBackgroundRadius(int backgroundRadius)
+    {
         this.backgroundRadius = backgroundRadius;
     }
 
@@ -896,7 +960,8 @@ public class SegmentedButton extends View {
      *
      * This is determined based on whether the rightButton variable is null
      */
-    private boolean isLeftButton() {
+    private boolean isLeftButton()
+    {
         return leftButton == null;
     }
 
@@ -905,7 +970,8 @@ public class SegmentedButton extends View {
      *
      * This is determined based on whether the rightButton variable is null
      */
-    private boolean isRightButton() {
+    private boolean isRightButton()
+    {
         return rightButton == null;
     }
 
@@ -917,7 +983,8 @@ public class SegmentedButton extends View {
      * leftButton, rightButton, rounded & width/height are completed.
      */
     @SuppressWarnings("SameParameterValue")
-    void setLeftButton(SegmentedButton leftButton) {
+    void setLeftButton(SegmentedButton leftButton)
+    {
         this.leftButton = leftButton;
     }
 
@@ -929,14 +996,16 @@ public class SegmentedButton extends View {
      * rightButton, rounded & width/height are completed.
      */
     @SuppressWarnings("SameParameterValue")
-    void setRightButton(SegmentedButton rightButton) {
+    void setRightButton(SegmentedButton rightButton)
+    {
         this.rightButton = rightButton;
     }
 
     /**
      * Returns whether this button is rounded
      */
-    public boolean isRounded() {
+    public boolean isRounded()
+    {
         return rounded;
     }
 
@@ -946,7 +1015,8 @@ public class SegmentedButton extends View {
      * Note: You must manually call setupBackgroundClipPath after all changes to background radius, leftButton,
      * rightButton, rounded & width/height are completed.
      */
-    public void setRounded(boolean rounded) {
+    public void setRounded(boolean rounded)
+    {
         this.rounded = rounded;
     }
 
@@ -958,7 +1028,8 @@ public class SegmentedButton extends View {
      *
      * @param selectedButtonRadius radius of corners for selected button in pixels
      */
-    void setSelectedButtonRadius(int selectedButtonRadius) {
+    void setSelectedButtonRadius(int selectedButtonRadius)
+    {
         this.selectedButtonRadius = selectedButtonRadius;
     }
 
@@ -976,9 +1047,11 @@ public class SegmentedButton extends View {
      * Note that this function internally calls setupBackgroundBitmaps() because a change in the clip path will
      * require updating the bitmaps
      */
-    void setupBackgroundClipPath() {
+    void setupBackgroundClipPath()
+    {
         // If there is no background radius then skip
-        if (backgroundRadius == 0) {
+        if (backgroundRadius == 0)
+        {
             backgroundClipPath = null;
 
             // Update background bitmaps
@@ -992,20 +1065,27 @@ public class SegmentedButton extends View {
         // Background radius, shorthand variable to make code cleaner
         final float br = backgroundRadius;
 
-        if (isRounded() || (isLeftButton() && isRightButton())) {
+        if (isRounded() || (isLeftButton() && isRightButton()))
+        {
             // Add radius on all sides, left & right
             backgroundClipPath = new Path();
             backgroundClipPath.addRoundRect(rectF,
-                    new float[]{br, br, br, br, br, br, br, br}, Direction.CW);
-        } else if (isLeftButton()) {
+                    new float[] {br, br, br, br, br, br, br, br}, Direction.CW);
+        }
+        else if (isLeftButton())
+        {
             // Add radius on left side only
             backgroundClipPath = new Path();
-            backgroundClipPath.addRoundRect(rectF, new float[]{br, br, 0, 0, 0, 0, br, br}, Direction.CW);
-        } else if (isRightButton()) {
+            backgroundClipPath.addRoundRect(rectF, new float[] {br, br, 0, 0, 0, 0, br, br}, Direction.CW);
+        }
+        else if (isRightButton())
+        {
             // Add radius on right side only
             backgroundClipPath = new Path();
-            backgroundClipPath.addRoundRect(rectF, new float[]{0, 0, br, br, br, br, 0, 0}, Direction.CW);
-        } else {
+            backgroundClipPath.addRoundRect(rectF, new float[] {0, 0, br, br, br, br, 0, 0}, Direction.CW);
+        }
+        else
+        {
             backgroundClipPath = null;
         }
 
@@ -1013,9 +1093,8 @@ public class SegmentedButton extends View {
         // right-most buttons) is not supported with hardware acceleration until API 18
         // Thus, switch to software acceleration if the background clip path is not null (meaning the edges are
         // rounded) and the current version is less than 18
-        if (backgroundClipPath != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        if (backgroundClipPath != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
             setLayerType(LAYER_TYPE_SOFTWARE, null);
-        }
 
         // Update background bitmaps
         setupBackgroundBitmaps();
@@ -1029,7 +1108,8 @@ public class SegmentedButton extends View {
      * rounded corners. In addition, this function should be called when the drawable or selected drawable changes,
      * the selected button radius changes, or the size of either drawable changes.
      */
-    void setupBackgroundBitmaps() {
+    void setupBackgroundBitmaps()
+    {
         Bitmap bitmap;
 
         // Setup background paint object to render background using a bitmap shader approach under three conditions:
@@ -1037,14 +1117,15 @@ public class SegmentedButton extends View {
         //      2. There is a background drawable
         //      3. Able to successfully create bitmap from drawable
         if (backgroundClipPath != null && backgroundDrawable != null
-                && (bitmap = getBitmapFromDrawable(backgroundDrawable)) != null) {
+                && (bitmap = getBitmapFromDrawable(backgroundDrawable)) != null)
+        {
             final BitmapShader backgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP, TileMode.CLAMP);
 
             backgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             backgroundPaint.setShader(backgroundBitmapShader);
-        } else {
-            backgroundPaint = null;
         }
+        else
+            backgroundPaint = null;
 
         // Setup selected background paint object to render background using a bitmap shader approach under three
         // conditions:
@@ -1052,15 +1133,16 @@ public class SegmentedButton extends View {
         //      2. There is a background drawable
         //      3. Able to successfully create bitmap from drawable
         if ((backgroundClipPath != null || selectedButtonRadius > 0) && selectedBackgroundDrawable != null
-                && (bitmap = getBitmapFromDrawable(selectedBackgroundDrawable)) != null) {
+                && (bitmap = getBitmapFromDrawable(selectedBackgroundDrawable)) != null)
+        {
             final BitmapShader selectedBackgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP,
                     TileMode.CLAMP);
 
             selectedBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             selectedBackgroundPaint.setShader(selectedBackgroundBitmapShader);
-        } else {
-            selectedBackgroundPaint = null;
         }
+        else
+            selectedBackgroundPaint = null;
     }
 
     /**
@@ -1068,18 +1150,23 @@ public class SegmentedButton extends View {
      *
      * This function should be called if the selected button radius is changed
      */
-    void setupSelectedButtonClipPath() {
+    void setupSelectedButtonClipPath()
+    {
         // Setup selected button radii
         // Object allocated here rather than in onDraw to increase performance
-        selectedButtonRadii = new float[]{selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+        selectedButtonRadii = new float[] {
+                selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
                 selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                selectedButtonRadius};
+                selectedButtonRadius
+        };
 
-        if (selectedButtonRadius > 0) {
+        if (selectedButtonRadius > 0)
+        {
             // Canvas.clipPath, used in onDraw for drawing the selected button clip path is not supported with
             // hardware acceleration until API 18. Thus, this switches to software acceleration if current Android
             // API version is less than 18.
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
+            {
                 setLayerType(LAYER_TYPE_SOFTWARE, null);
             }
         }
@@ -1098,8 +1185,10 @@ public class SegmentedButton extends View {
      * @param dashWidth Width of the dash for border, in pixels. Value of 0px means solid line (default is 0px)
      * @param dashGap   Width of the gap for border, in pixels.
      */
-    void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
-        if (width > 0) {
+    void setSelectedButtonBorder(int width, @ColorInt int color, int dashWidth, int dashGap)
+    {
+        if (width > 0)
+        {
             // Allocate Paint object for drawing border here
             // Used in onDraw to draw the border around the selected button
             selectedButtonBorderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -1107,10 +1196,13 @@ public class SegmentedButton extends View {
             selectedButtonBorderPaint.setStrokeWidth(width);
             selectedButtonBorderPaint.setColor(color);
 
-            if (dashWidth > 0.0f) {
-                selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[]{dashWidth, dashGap}, 0));
+            if (dashWidth > 0.0f)
+            {
+                selectedButtonBorderPaint.setPathEffect(new DashPathEffect(new float[] {dashWidth, dashGap}, 0));
             }
-        } else {
+        }
+        else
+        {
             // If the width is 0, then disable drawing border
             selectedButtonBorderPaint = null;
         }
@@ -1119,11 +1211,13 @@ public class SegmentedButton extends View {
     }
 
     @Override
-    public void setVisibility(final int visibility) {
+    public void setVisibility(final int visibility)
+    {
         super.setVisibility(visibility);
 
         // Notify the parent button group of change
-        if (onVisibilityChangedListener != null) {
+        if (onVisibilityChangedListener != null)
+        {
             onVisibilityChangedListener.onVisibilityChanged(this, visibility);
         }
     }
@@ -1139,8 +1233,10 @@ public class SegmentedButton extends View {
      *
      * @param drawable Drawable to set as the background
      */
-    void setDefaultBackground(@Nullable Drawable drawable) {
-        if (backgroundDrawable == null && drawable != null) {
+    void setDefaultBackground(@Nullable Drawable drawable)
+    {
+        if (backgroundDrawable == null && drawable != null)
+        {
             // Make sure to clone the drawable so that we can set the bounds on it
             backgroundDrawable = drawable.getConstantState().newDrawable();
         }
@@ -1157,8 +1253,10 @@ public class SegmentedButton extends View {
      *
      * @param drawable Drawable to set as the background
      */
-    void setDefaultSelectedBackground(@Nullable Drawable drawable) {
-        if (selectedBackgroundDrawable == null && drawable != null) {
+    void setDefaultSelectedBackground(@Nullable Drawable drawable)
+    {
+        if (selectedBackgroundDrawable == null && drawable != null)
+        {
             // Make sure to clone the drawable so that we can set the bounds on it
             selectedBackgroundDrawable = drawable.getConstantState().newDrawable();
         }
@@ -1171,7 +1269,8 @@ public class SegmentedButton extends View {
      *
      * @return the current background drawable when the button is not selected
      */
-    public Drawable getBackground() {
+    public Drawable getBackground()
+    {
         return backgroundDrawable;
     }
 
@@ -1181,7 +1280,8 @@ public class SegmentedButton extends View {
      * @param drawable drawable to set the background to
      */
     @Override
-    public void setBackground(final Drawable drawable) {
+    public void setBackground(final Drawable drawable)
+    {
         backgroundDrawable = drawable;
         backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
 
@@ -1198,11 +1298,15 @@ public class SegmentedButton extends View {
      *
      * @param color color to set the background to
      */
-    public void setBackground(@ColorInt int color) {
-        if (backgroundDrawable instanceof ColorDrawable) {
+    public void setBackground(@ColorInt int color)
+    {
+        if (backgroundDrawable instanceof ColorDrawable)
+        {
             // If the current drawable is a ColorDrawable, just change the color
-            ((ColorDrawable) backgroundDrawable.mutate()).setColor(color);
-        } else {
+            ((ColorDrawable)backgroundDrawable.mutate()).setColor(color);
+        }
+        else
+        {
             backgroundDrawable = new ColorDrawable(color);
             backgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
         }
@@ -1222,7 +1326,8 @@ public class SegmentedButton extends View {
      * @param color color to set the background to
      */
     @Override
-    public void setBackgroundColor(@ColorInt int color) {
+    public void setBackgroundColor(@ColorInt int color)
+    {
         setBackground(color);
     }
 
@@ -1233,7 +1338,8 @@ public class SegmentedButton extends View {
      *
      * @return the current background drawable when the button is selected
      */
-    public Drawable getSelectedBackground() {
+    public Drawable getSelectedBackground()
+    {
         return selectedBackgroundDrawable;
     }
 
@@ -1242,7 +1348,8 @@ public class SegmentedButton extends View {
      *
      * @param drawable drawable to set the background to
      */
-    public void setSelectedBackground(final Drawable drawable) {
+    public void setSelectedBackground(final Drawable drawable)
+    {
         selectedBackgroundDrawable = drawable;
         selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
 
@@ -1259,11 +1366,15 @@ public class SegmentedButton extends View {
      *
      * @param color color to set the background to
      */
-    public void setSelectedBackground(@ColorInt int color) {
-        if (selectedBackgroundDrawable instanceof ColorDrawable) {
+    public void setSelectedBackground(@ColorInt int color)
+    {
+        if (selectedBackgroundDrawable instanceof ColorDrawable)
+        {
             // If the current drawable is a ColorDrawable, just change the color
-            ((ColorDrawable) selectedBackgroundDrawable.mutate()).setColor(color);
-        } else {
+            ((ColorDrawable)selectedBackgroundDrawable.mutate()).setColor(color);
+        }
+        else
+        {
             selectedBackgroundDrawable = new ColorDrawable(color);
             selectedBackgroundDrawable.setBounds(0, 0, getWidth(), getHeight());
         }
@@ -1279,7 +1390,8 @@ public class SegmentedButton extends View {
      *
      * @param color color to set the background to
      */
-    public void setSelectedBackgroundColor(@ColorInt int color) {
+    public void setSelectedBackgroundColor(@ColorInt int color)
+    {
         setSelectedBackground(color);
     }
 
@@ -1288,7 +1400,8 @@ public class SegmentedButton extends View {
      *
      * The ripple color is a tint color applied on top of the button when it is pressed
      */
-    public int getRippleColor() {
+    public int getRippleColor()
+    {
         return rippleColor;
     }
 
@@ -1303,11 +1416,15 @@ public class SegmentedButton extends View {
      *
      * @param enabled whether or not to enable the ripple effect for this button
      */
-    void setRipple(boolean enabled) {
-        if (enabled) {
+    void setRipple(boolean enabled)
+    {
+        if (enabled)
+        {
             // Recreate the ripple drawable and setup with the ripple color
             setRipple(rippleColor);
-        } else {
+        }
+        else
+        {
             // Set both ripple drawables to null so that we do not draw the ripple
             rippleDrawableLollipop = null;
             rippleDrawable = null;
@@ -1319,10 +1436,12 @@ public class SegmentedButton extends View {
      *
      * @param color color to set for the ripple effect for this button
      */
-    public void setRipple(@ColorInt int color) {
+    public void setRipple(@ColorInt int color)
+    {
         rippleColor = color;
 
-        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)
+        {
             rippleDrawableLollipop = new RippleDrawable(ColorStateList.valueOf(rippleColor), null, null);
             // setCallback on Drawable allows animations to be scheduled and the drawable to invalidate the view on
             // animation
@@ -1331,7 +1450,9 @@ public class SegmentedButton extends View {
 
             // Disable/nullify the pre-lollipop RippleDrawable backport
             rippleDrawable = null;
-        } else {
+        }
+        else
+        {
             rippleDrawable = new codetail.graphics.drawables.RippleDrawable(ColorStateList.valueOf(rippleColor), null,
                     null);
             // setCallback on Drawable allows animations to be scheduled and the drawable to invalidate the view on
@@ -1351,7 +1472,8 @@ public class SegmentedButton extends View {
     /**
      * Returns the drawable for the button or null if no drawable is set
      */
-    public Drawable getDrawable() {
+    public Drawable getDrawable()
+    {
         return drawable;
     }
 
@@ -1362,7 +1484,8 @@ public class SegmentedButton extends View {
      *
      * @param drawable Drawable to set for the button
      */
-    public void setDrawable(final @Nullable Drawable drawable) {
+    public void setDrawable(final @Nullable Drawable drawable)
+    {
         this.drawable = drawable;
 
         // Request a layout, drawable may have different size and things need to be rearranged
@@ -1380,7 +1503,8 @@ public class SegmentedButton extends View {
      * The drawable padding is the space between the drawable and text, in pixels. If the drawable or the text is not
      * present, then the padding is ignored.
      */
-    public int getDrawablePadding() {
+    public int getDrawablePadding()
+    {
         return drawablePadding;
     }
 
@@ -1392,7 +1516,8 @@ public class SegmentedButton extends View {
      *
      * @param padding padding in pixels to set for the drawable
      */
-    public void setDrawablePadding(final int padding) {
+    public void setDrawablePadding(final int padding)
+    {
         drawablePadding = padding;
 
         requestLayout();
@@ -1406,7 +1531,8 @@ public class SegmentedButton extends View {
     /**
      * Whether or not there is a tint color applied to the drawable when the button is not selected
      */
-    public boolean hasDrawableTint() {
+    public boolean hasDrawableTint()
+    {
         return hasDrawableTint;
     }
 
@@ -1415,7 +1541,8 @@ public class SegmentedButton extends View {
      *
      * If hasDrawableTint is false, then this value will be undefined
      */
-    public int getDrawableTint() {
+    public int getDrawableTint()
+    {
         return drawableTint;
     }
 
@@ -1426,7 +1553,8 @@ public class SegmentedButton extends View {
      *
      * @param tint color for the drawable tint
      */
-    public void setDrawableTint(final @ColorInt int tint) {
+    public void setDrawableTint(final @ColorInt int tint)
+    {
         hasDrawableTint = true;
         drawableTint = tint;
 
@@ -1439,7 +1567,8 @@ public class SegmentedButton extends View {
     /**
      * Remove drawable tint color so that the normal drawable is shown when the button is not selected
      */
-    public void removeDrawableTint() {
+    public void removeDrawableTint()
+    {
         hasDrawableTint = false;
         drawableColorFilter = null;
 
@@ -1449,7 +1578,8 @@ public class SegmentedButton extends View {
     /**
      * Whether or not there is a tint color applied to the drawable when the button is selected
      */
-    public boolean hasSelectedDrawableTint() {
+    public boolean hasSelectedDrawableTint()
+    {
         return hasSelectedDrawableTint;
     }
 
@@ -1458,7 +1588,8 @@ public class SegmentedButton extends View {
      *
      * If hasSelectedDrawableTint is false, then this value will be undefined
      */
-    public int getSelectedDrawableTint() {
+    public int getSelectedDrawableTint()
+    {
         return selectedDrawableTint;
     }
 
@@ -1469,7 +1600,8 @@ public class SegmentedButton extends View {
      *
      * @param tint color for the drawable tint
      */
-    public void setSelectedDrawableTint(final @ColorInt int tint) {
+    public void setSelectedDrawableTint(final @ColorInt int tint)
+    {
         hasSelectedDrawableTint = true;
         selectedDrawableTint = tint;
 
@@ -1482,7 +1614,8 @@ public class SegmentedButton extends View {
     /**
      * Remove drawable tint color so that the normal drawable is shown when the button is selected
      */
-    public void removeSelectedDrawableTint() {
+    public void removeSelectedDrawableTint()
+    {
         hasSelectedDrawableTint = false;
         selectedDrawableColorFilter = null;
 
@@ -1492,7 +1625,8 @@ public class SegmentedButton extends View {
     /**
      * Whether or not the drawable has a width that was explicitly given
      */
-    public boolean hasDrawableWidth() {
+    public boolean hasDrawableWidth()
+    {
         return hasDrawableWidth;
     }
 
@@ -1501,7 +1635,8 @@ public class SegmentedButton extends View {
      *
      * If hasDrawableWidth is false, then this value will be undefined
      */
-    public int getDrawableWidth() {
+    public int getDrawableWidth()
+    {
         return drawableWidth;
     }
 
@@ -1513,7 +1648,8 @@ public class SegmentedButton extends View {
      *
      * @param width size in pixels of the width of the drawable
      */
-    public void setDrawableWidth(final int width) {
+    public void setDrawableWidth(final int width)
+    {
         hasDrawableWidth = (width != -1);
         drawableWidth = width;
 
@@ -1529,7 +1665,8 @@ public class SegmentedButton extends View {
     /**
      * Whether or not the drawable has a height that was explicitly given
      */
-    public boolean hasDrawableHeight() {
+    public boolean hasDrawableHeight()
+    {
         return hasDrawableHeight;
     }
 
@@ -1538,7 +1675,8 @@ public class SegmentedButton extends View {
      *
      * If hasDrawableHeight is false, then this value will be undefined
      */
-    public int getDrawableHeight() {
+    public int getDrawableHeight()
+    {
         return drawableHeight;
     }
 
@@ -1550,7 +1688,8 @@ public class SegmentedButton extends View {
      *
      * @param height size in pixels of the height of the drawable
      */
-    public void setDrawableHeight(final int height) {
+    public void setDrawableHeight(final int height)
+    {
         hasDrawableHeight = (height != -1);
         drawableHeight = height;
 
@@ -1568,7 +1707,8 @@ public class SegmentedButton extends View {
      *
      * The drawable can be placed to the left, top, right, or bottom of the text via this parameter
      */
-    public int getDrawableGravity() {
+    public int getDrawableGravity()
+    {
         return drawableGravity;
     }
 
@@ -1586,7 +1726,8 @@ public class SegmentedButton extends View {
      *
      * @param gravity new drawable gravity
      */
-    public void setDrawableGravity(final @GravityOptions int gravity) {
+    public void setDrawableGravity(final @GravityOptions int gravity)
+    {
         drawableGravity = gravity;
 
         // Request relayout because the drawable width is different now
@@ -1603,7 +1744,8 @@ public class SegmentedButton extends View {
      *
      * If no text is being shown, this will be either null or an empty string
      */
-    public String getText() {
+    public String getText()
+    {
         return text;
     }
 
@@ -1614,16 +1756,16 @@ public class SegmentedButton extends View {
      *
      * @param text new string to set text to in the button
      */
-    public void setText(final @Nullable String text) {
+    public void setText(final @Nullable String text)
+    {
         this.hasText = (text != null && !text.isEmpty());
         this.text = text;
 
         initText();
-
         requestLayout();
 
         // Calculate new positions and bounds for text & drawable
-        // This may be redundant if the case that onSizeChanged gets called but there are cases where the size doesnt
+        // This may be redundant in the case that onSizeChanged gets called but there are cases where the size doesnt
         // change but the positions still need to be recalculated
         updateSize();
     }
@@ -1631,7 +1773,8 @@ public class SegmentedButton extends View {
     /**
      * Returns the text color when the button is not selected
      */
-    public int getTextColor() {
+    public int getTextColor()
+    {
         return textColor;
     }
 
@@ -1640,7 +1783,8 @@ public class SegmentedButton extends View {
      *
      * @param color text color
      */
-    public void setTextColor(final @ColorInt int color) {
+    public void setTextColor(final @ColorInt int color)
+    {
         textColor = color;
 
         invalidate();
@@ -1651,7 +1795,8 @@ public class SegmentedButton extends View {
      *
      * If this is false, then the text color will be the same as when the button is unselected
      */
-    public boolean hasSelectedTextColor() {
+    public boolean hasSelectedTextColor()
+    {
         return hasSelectedTextColor;
     }
 
@@ -1660,7 +1805,8 @@ public class SegmentedButton extends View {
      *
      * If hasSelectedTextColor is false, then this returned value is undefined
      */
-    public int getSelectedTextColor() {
+    public int getSelectedTextColor()
+    {
         return selectedTextColor;
     }
 
@@ -1669,7 +1815,8 @@ public class SegmentedButton extends View {
      *
      * @param color text color
      */
-    public void setSelectedTextColor(final @ColorInt int color) {
+    public void setSelectedTextColor(final @ColorInt int color)
+    {
         hasSelectedTextColor = true;
         selectedTextColor = color;
 
@@ -1681,7 +1828,8 @@ public class SegmentedButton extends View {
      *
      * The text color of the button when selected will be the normal text color of the button
      */
-    public void removeSelectedTextColor() {
+    public void removeSelectedTextColor()
+    {
         hasSelectedTextColor = false;
 
         invalidate();
@@ -1690,7 +1838,8 @@ public class SegmentedButton extends View {
     /**
      * Return the size of the text in pixels
      */
-    public float getTextSize() {
+    public float getTextSize()
+    {
         return textSize;
     }
 
@@ -1699,15 +1848,15 @@ public class SegmentedButton extends View {
      *
      * @param size new size in pixels of the text
      */
-    public void setTextSize(final float size) {
+    public void setTextSize(final float size)
+    {
         textSize = size;
-
-        if (!hasText) {
+        if (!hasText)
             return;
-        }
 
         textPaint.setTextSize(size);
 
+        initText();
         requestLayout();
 
         // Calculate new positions and bounds for text & drawable
@@ -1719,7 +1868,8 @@ public class SegmentedButton extends View {
     /**
      * Return the current typeface used for drawing text
      */
-    public Typeface getTextTypeface() {
+    public Typeface getTextTypeface()
+    {
         return textTypeface;
     }
 
@@ -1728,11 +1878,11 @@ public class SegmentedButton extends View {
      *
      * @param typeface new typeface for text
      */
-    public void setTextTypeface(final Typeface typeface) {
+    public void setTextTypeface(final Typeface typeface)
+    {
         textTypeface = typeface;
 
         initText();
-
         requestLayout();
 
         // Calculate new positions and bounds for text & drawable
@@ -1748,7 +1898,8 @@ public class SegmentedButton extends View {
      *
      * DO NOT USE
      */
-    void _setOnVisibilityChangedListener(OnVisibilityChangedListener listener) {
+    void _setOnVisibilityChangedListener(OnVisibilityChangedListener listener)
+    {
         this.onVisibilityChangedListener = listener;
     }
 
@@ -1761,8 +1912,10 @@ public class SegmentedButton extends View {
      *
      * @param vectorDrawable vector drawable to convert to a bitmap
      */
-    public static Bitmap getBitmapFromVectorDrawable(Drawable vectorDrawable) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+    public static Bitmap getBitmapFromVectorDrawable(Drawable vectorDrawable)
+    {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+        {
             vectorDrawable = (DrawableCompat.wrap(vectorDrawable)).mutate();
         }
 
@@ -1782,25 +1935,28 @@ public class SegmentedButton extends View {
      *
      * @param drawable drawable to convert to a bitmap
      */
-    private static Bitmap getBitmapFromDrawable(@Nullable Drawable drawable) {
-        if (drawable == null) {
+    private static Bitmap getBitmapFromDrawable(@Nullable Drawable drawable)
+    {
+        if (drawable == null)
             return null;
-        }
 
         // Return bitmap if drawable is BitmapDrawable
-        if (drawable instanceof BitmapDrawable) {
-            return ((BitmapDrawable) drawable).getBitmap();
-        }
+        if (drawable instanceof BitmapDrawable)
+            return ((BitmapDrawable)drawable).getBitmap();
 
-        try {
+        try
+        {
             Bitmap bitmap;
 
-            if (drawable instanceof ColorDrawable) {
+            if (drawable instanceof ColorDrawable)
+            {
                 // Create a bitmap of fixed size for ColorDrawable since it inherently has no size
                 // Ideally, this size can be small because the bitmap can be stretched to fit any width/height
                 // without loss of quality
                 bitmap = Bitmap.createBitmap(COLORDRAWABLE_SIZE, COLORDRAWABLE_SIZE, BITMAP_CONFIG);
-            } else if (drawable instanceof GradientDrawable) {
+            }
+            else if (drawable instanceof GradientDrawable)
+            {
                 // GradientDrawable ALSO doesn't have a inherent size
                 // However, the size of the bitmap used to represent the GradientDrawable should be the size of the
                 // bounds.
@@ -1808,12 +1964,13 @@ public class SegmentedButton extends View {
                 // Return null if bounds are 0, this occurs if function is called before button is laid out
                 final Rect bounds = drawable.getBounds();
 
-                if (bounds.width() > 0 && bounds.height() > 0) {
+                if (bounds.width() > 0 && bounds.height() > 0)
                     bitmap = Bitmap.createBitmap(bounds.width(), bounds.height(), BITMAP_CONFIG);
-                } else {
+                else
                     return null;
-                }
-            } else {
+            }
+            else
+            {
                 // Otherwise, create bitmap based on intrinsic size of the drawable
                 bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
                         BITMAP_CONFIG);
@@ -1830,7 +1987,9 @@ public class SegmentedButton extends View {
             drawable.setBounds(bounds);
 
             return bitmap;
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             // There was an unexpected problem, print out the stack track
             e.printStackTrace();
             return null;
@@ -1846,8 +2005,8 @@ public class SegmentedButton extends View {
      *
      * This is an internal listener meant to be used ONLY by the SegmentedButtonGroup
      */
-    public interface OnVisibilityChangedListener {
-
+    public interface OnVisibilityChangedListener
+    {
         void onVisibilityChanged(SegmentedButton button, int visibility);
     }
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -32,7 +32,6 @@ import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -64,10 +63,10 @@ public class SegmentedButton extends View
     private static final int COLORDRAWABLE_SIZE = 2;
 
     @IntDef(flag = true, value = {
-            Gravity.LEFT,
-            Gravity.RIGHT,
-            Gravity.TOP,
-            Gravity.BOTTOM,
+        Gravity.LEFT,
+        Gravity.RIGHT,
+        Gravity.TOP,
+        Gravity.BOTTOM,
     })
     @Retention(RetentionPolicy.SOURCE)
     private @interface GravityOptions {}
@@ -276,7 +275,7 @@ public class SegmentedButton extends View
 
         // Convert 14sp to pixels for default value on text size
         final float px14sp = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 14.0f,
-                context.getResources().getDisplayMetrics());
+            context.getResources().getDisplayMetrics());
         textSize = ta.getDimension(R.styleable.SegmentedButton_textSize, px14sp);
 
         final boolean hasFontFamily = ta.hasValue(R.styleable.SegmentedButton_android_fontFamily);
@@ -305,7 +304,7 @@ public class SegmentedButton extends View
                     // On lower API Android versions, fontFamily returns 0 for default fonts such as "sans-serif" and
                     // "monospace". Thus, we get the font as a string and then try to load that way
                     textTypeface = Typeface.create(ta.getString(R.styleable.SegmentedButton_android_fontFamily),
-                            textStyle);
+                        textStyle);
                 }
             }
         }
@@ -339,7 +338,6 @@ public class SegmentedButton extends View
 
         // Initial kickstart to setup the text layout by assuming the text will be all in one line
         textMaxWidth = (int)textPaint.measureText(text);
-        Log.v(TAG, String.format("initText called(%s): %d", text, textMaxWidth));
         if (Build.VERSION.SDK_INT >= VERSION_CODES.M)
         {
             textStaticLayout = StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, textMaxWidth).build();
@@ -347,7 +345,7 @@ public class SegmentedButton extends View
         else
         {
             textStaticLayout = new StaticLayout(text, textPaint, textMaxWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0,
-                    false);
+                false);
         }
     }
 
@@ -358,7 +356,7 @@ public class SegmentedButton extends View
         // API 28 has a bug with vector drawables where the selected tint color is always applied to the drawable
         // To prevent this, the vector drawable is converted to a bitmap
         if ((VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && drawable instanceof VectorDrawable)
-                || drawable instanceof VectorDrawableCompat)
+            || drawable instanceof VectorDrawableCompat)
         {
             Bitmap bitmap = getBitmapFromVectorDrawable(drawable);
             return new BitmapDrawable(context.getResources(), bitmap);
@@ -400,7 +398,7 @@ public class SegmentedButton extends View
 
         // Calculate drawable width, 0 if null, drawableWidth if set, otherwise intrinsic width
         final int drawableWidth = drawable != null ? hasDrawableWidth ? this.drawableWidth
-                : drawable.getIntrinsicWidth() : 0;
+            : drawable.getIntrinsicWidth() : 0;
         // For the text width, assume that it is in a single line with no wrapping which would be textMaxWidth
         // This variable is used to calculate the desired width and the desire is for it all to be in a single line
         final int textWidth = hasText ? textMaxWidth : 0;
@@ -436,7 +434,7 @@ public class SegmentedButton extends View
         // Note that the height is the static layout height which may or may not be multi-lined
         // Calculate drawable height, 0 if null, drawableHeight if set, otherwise intrinsic height
         final int drawableHeight = drawable != null ? hasDrawableHeight ? this.drawableHeight
-                : drawable.getIntrinsicHeight() : 0;
+            : drawable.getIntrinsicHeight() : 0;
         final int textHeight = hasText ? textStaticLayout.getHeight() : 0;
 
         int desiredHeight = getPaddingTop() + getPaddingBottom();
@@ -461,11 +459,6 @@ public class SegmentedButton extends View
         //      - MeasureSpec.UNSPECIFIED: Set height to desired size
         height = resolveSize(desiredHeight, heightMeasureSpec);
 
-        Log.v(TAG, String.format("onMeasure called(%s): %d %d", text, widthMeasureSpec, heightMeasureSpec));
-        Log.v(TAG, String.format("Desired width: %d Width: %d", desiredWidth, width));
-        Log.v(TAG, String.format("Desired height: %d Height: %d", desiredHeight, height));
-        Log.v(TAG, String.format("Text info: %d %d %d", textMaxWidth, getPaddingTop(), getPaddingRight()));
-
         // Required to be called to notify the View of the width & height decided
         setMeasuredDimension(width, height);
     }
@@ -477,8 +470,6 @@ public class SegmentedButton extends View
 
         // Calculate new positions and bounds for text & drawable
         updateSize();
-
-        Log.v(TAG, String.format("onSizeChanged(%s): %d %d %d %d", text, w, h, oldw, oldh));
 
         // Recalculate the background clip path since width & height have changed
         setupBackgroundClipPath();
@@ -520,7 +511,7 @@ public class SegmentedButton extends View
         else
         {
             textStaticLayout = new StaticLayout(text, textPaint, textWidth, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0,
-                    false);
+                false);
         }
     }
 
@@ -535,18 +526,18 @@ public class SegmentedButton extends View
         final int textWidth = hasText ? textStaticLayout.getWidth() : 0;
         final int textHeight = hasText ? textStaticLayout.getHeight() : 0;
         final int drawableWidth = drawable != null ? hasDrawableWidth ? this.drawableWidth
-                : drawable.getIntrinsicWidth() : 0;
+            : drawable.getIntrinsicWidth() : 0;
         final int drawableHeight = drawable != null ? hasDrawableHeight ? this.drawableHeight
-                : drawable.getIntrinsicHeight() : 0;
+            : drawable.getIntrinsicHeight() : 0;
 
         // Calculates the X/Y positions of the text and drawable now that the measured size is known
         if (Gravity.isHorizontal(drawableGravity))
         {
             // Calculate Y position for horizontal gravity, i.e. center the drawable and/or text if necessary
             textPosition.y = getPaddingTop()
-                    + (height - getPaddingTop() - getPaddingBottom() - textHeight) / 2.0f;
+                + (height - getPaddingTop() - getPaddingBottom() - textHeight) / 2.0f;
             drawablePosition.y = getPaddingTop()
-                    + (height - getPaddingTop() - getPaddingBottom() - drawableHeight) / 2.0f;
+                + (height - getPaddingTop() - getPaddingBottom() - drawableHeight) / 2.0f;
 
             // Calculate the starting X position with horizontal gravity
             // startPosition is half of the remaining space to center the drawable and text
@@ -568,9 +559,9 @@ public class SegmentedButton extends View
         {
             // Calculate X position for vertical gravity, i.e. center the drawable and/or text horizontally if necessary
             textPosition.x = getPaddingLeft()
-                    + (width - getPaddingLeft() - getPaddingRight() - textWidth) / 2.0f;
+                + (width - getPaddingLeft() - getPaddingRight() - textWidth) / 2.0f;
             drawablePosition.x = getPaddingLeft()
-                    + (width - getPaddingLeft() - getPaddingRight() - drawableWidth) / 2.0f;
+                + (width - getPaddingLeft() - getPaddingRight() - drawableWidth) / 2.0f;
 
             // Calculate the starting Y position with vertical gravity
             // startPosition is half of the remaining space to center the drawable and text
@@ -593,7 +584,7 @@ public class SegmentedButton extends View
         if (drawable != null)
         {
             drawable.setBounds((int)drawablePosition.x, (int)drawablePosition.y,
-                    (int)drawablePosition.x + drawableWidth, (int)drawablePosition.y + drawableHeight);
+                (int)drawablePosition.x + drawableWidth, (int)drawablePosition.y + drawableHeight);
         }
 
         // Set bounds of background drawable if it exists
@@ -642,7 +633,6 @@ public class SegmentedButton extends View
         }
 
         // Draw text (unselected)
-        Log.v(TAG, String.format("onDraw called(%s)", text));
         if (hasText)
         {
             canvas.save();
@@ -960,7 +950,7 @@ public class SegmentedButton extends View
      *
      * This is determined based on whether the rightButton variable is null
      */
-    private boolean isLeftButton()
+    public boolean isLeftButton()
     {
         return leftButton == null;
     }
@@ -970,7 +960,7 @@ public class SegmentedButton extends View
      *
      * This is determined based on whether the rightButton variable is null
      */
-    private boolean isRightButton()
+    public boolean isRightButton()
     {
         return rightButton == null;
     }
@@ -1070,7 +1060,7 @@ public class SegmentedButton extends View
             // Add radius on all sides, left & right
             backgroundClipPath = new Path();
             backgroundClipPath.addRoundRect(rectF,
-                    new float[] {br, br, br, br, br, br, br, br}, Direction.CW);
+                new float[] {br, br, br, br, br, br, br, br}, Direction.CW);
         }
         else if (isLeftButton())
         {
@@ -1117,7 +1107,7 @@ public class SegmentedButton extends View
         //      2. There is a background drawable
         //      3. Able to successfully create bitmap from drawable
         if (backgroundClipPath != null && backgroundDrawable != null
-                && (bitmap = getBitmapFromDrawable(backgroundDrawable)) != null)
+            && (bitmap = getBitmapFromDrawable(backgroundDrawable)) != null)
         {
             final BitmapShader backgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP, TileMode.CLAMP);
 
@@ -1133,10 +1123,10 @@ public class SegmentedButton extends View
         //      2. There is a background drawable
         //      3. Able to successfully create bitmap from drawable
         if ((backgroundClipPath != null || selectedButtonRadius > 0) && selectedBackgroundDrawable != null
-                && (bitmap = getBitmapFromDrawable(selectedBackgroundDrawable)) != null)
+            && (bitmap = getBitmapFromDrawable(selectedBackgroundDrawable)) != null)
         {
             final BitmapShader selectedBackgroundBitmapShader = new BitmapShader(bitmap, TileMode.CLAMP,
-                    TileMode.CLAMP);
+                TileMode.CLAMP);
 
             selectedBackgroundPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
             selectedBackgroundPaint.setShader(selectedBackgroundBitmapShader);
@@ -1155,9 +1145,9 @@ public class SegmentedButton extends View
         // Setup selected button radii
         // Object allocated here rather than in onDraw to increase performance
         selectedButtonRadii = new float[] {
-                selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
-                selectedButtonRadius
+            selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+            selectedButtonRadius, selectedButtonRadius, selectedButtonRadius, selectedButtonRadius,
+            selectedButtonRadius
         };
 
         if (selectedButtonRadius > 0)
@@ -1454,7 +1444,7 @@ public class SegmentedButton extends View
         else
         {
             rippleDrawable = new codetail.graphics.drawables.RippleDrawable(ColorStateList.valueOf(rippleColor), null,
-                    null);
+                null);
             // setCallback on Drawable allows animations to be scheduled and the drawable to invalidate the view on
             // animation
             rippleDrawable.setCallback(this);
@@ -1920,7 +1910,7 @@ public class SegmentedButton extends View
         }
 
         Bitmap bitmap = Bitmap.createBitmap(vectorDrawable.getIntrinsicWidth(),
-                vectorDrawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+            vectorDrawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
         vectorDrawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         vectorDrawable.draw(canvas);
@@ -1973,7 +1963,7 @@ public class SegmentedButton extends View
             {
                 // Otherwise, create bitmap based on intrinsic size of the drawable
                 bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(),
-                        BITMAP_CONFIG);
+                    BITMAP_CONFIG);
             }
 
             // Create canvas using bitmap

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -18,7 +18,6 @@ import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.MotionEvent;
 import android.view.View;
@@ -44,14 +43,13 @@ import androidx.core.content.ContextCompat;
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator;
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator;
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator;
-import com.addisonelliott.segmentedbutton.SegmentedButton.OnVisibilityChangedListener;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SegmentedButtonGroup extends LinearLayout {
-
+public class SegmentedButtonGroup extends LinearLayout
+{
     // region Variables & Constants
     private static final String TAG = "SegmentedButtonGroup";
 
@@ -73,11 +71,13 @@ public class SegmentedButtonGroup extends LinearLayout {
     // Interface defined for linting purposes to ensure that an animation interpolator value (integer type) is one
     // of the valid values
     @Retention(RetentionPolicy.SOURCE)
-    @IntDef({ANIM_INTERPOLATOR_NONE, ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN, ANIM_INTERPOLATOR_BOUNCE,
+    @IntDef({
+            ANIM_INTERPOLATOR_NONE, ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN, ANIM_INTERPOLATOR_BOUNCE,
             ANIM_INTERPOLATOR_LINEAR, ANIM_INTERPOLATOR_DECELERATE, ANIM_INTERPOLATOR_CYCLE,
             ANIM_INTERPOLATOR_ANTICIPATE, ANIM_INTERPOLATOR_ACCELERATE_DECELERATE, ANIM_INTERPOLATOR_ACCELERATE,
             ANIM_INTERPOLATOR_ANTICIPATE_OVERSHOOT, ANIM_INTERPOLATOR_FAST_OUT_LINEAR_IN,
-            ANIM_INTERPOLATOR_LINEAR_OUT_SLOW_IN, ANIM_INTERPOLATOR_OVERSHOOT})
+            ANIM_INTERPOLATOR_LINEAR_OUT_SLOW_IN, ANIM_INTERPOLATOR_OVERSHOOT
+    })
     public @interface AnimationInterpolator {}
 
     // This ViewGroup consists of a FrameLayout as it's child which contains three items:
@@ -176,39 +176,43 @@ public class SegmentedButtonGroup extends LinearLayout {
 
     // region Constructor
 
-    public SegmentedButtonGroup(Context context) {
+    public SegmentedButtonGroup(Context context)
+    {
         super(context);
 
         init(context, null);
     }
 
-    public SegmentedButtonGroup(Context context, AttributeSet attrs) {
+    public SegmentedButtonGroup(Context context, AttributeSet attrs)
+    {
         super(context, attrs);
 
         init(context, attrs);
     }
 
-    public SegmentedButtonGroup(Context context, AttributeSet attrs, int defStyleAttr) {
+    public SegmentedButtonGroup(Context context, AttributeSet attrs, int defStyleAttr)
+    {
         super(context, attrs, defStyleAttr);
 
         init(context, attrs);
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public SegmentedButtonGroup(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    public SegmentedButtonGroup(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes)
+    {
         super(context, attrs, defStyleAttr, defStyleRes);
 
         init(context, attrs);
     }
 
-    private void init(Context context, @Nullable AttributeSet attrs) {
+    private void init(Context context, @Nullable AttributeSet attrs)
+    {
         // Create and set outline provider for the segmented button group
         // This is used to provide an outline for the layout because it may have rounded corners
         // The primary benefit to using this is that shadows will follow the contour of the outline rather than the
         // rectangular bounds
-        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)
             setOutlineProvider(new OutlineProvider());
-        }
 
         buttons = new ArrayList<>();
 
@@ -260,21 +264,20 @@ public class SegmentedButtonGroup extends LinearLayout {
         getAttributes(context, attrs);
     }
 
-    private void getAttributes(Context context, @Nullable AttributeSet attrs) {
+    private void getAttributes(Context context, @Nullable AttributeSet attrs)
+    {
         // According to docs for obtainStyledAttributes, attrs can be null and I assume that each value will be set
         // to the default
         final TypedArray ta = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SegmentedButtonGroup, 0, 0);
 
         // Load background if available, this can be a drawable or a color
         // Note: Not well documented but getDrawable will return a ColorDrawable if a color is specified
-        if (ta.hasValue(R.styleable.SegmentedButtonGroup_android_background)) {
+        if (ta.hasValue(R.styleable.SegmentedButtonGroup_android_background))
             backgroundDrawable = ta.getDrawable(R.styleable.SegmentedButtonGroup_android_background);
-        }
 
         // Load background on selection if available, can be drawable or color
-        if (ta.hasValue(R.styleable.SegmentedButtonGroup_selectedBackground)) {
+        if (ta.hasValue(R.styleable.SegmentedButtonGroup_selectedBackground))
             selectedBackgroundDrawable = ta.getDrawable(R.styleable.SegmentedButtonGroup_selectedBackground);
-        }
 
         // Note: Must read radius before setBorder call in order to round the border corners!
         radius = ta.getDimensionPixelSize(R.styleable.SegmentedButtonGroup_radius, 0);
@@ -320,23 +323,32 @@ public class SegmentedButtonGroup extends LinearLayout {
         // Load divider value if available, the divider can be either a drawable resource or a color
         // Load the TypedValue first and check the type to determine if color or drawable
         final TypedValue value = new TypedValue();
-        if (ta.getValue(R.styleable.SegmentedButtonGroup_divider, value)) {
-            if (value.type == TypedValue.TYPE_REFERENCE || value.type == TypedValue.TYPE_STRING) {
+        if (ta.getValue(R.styleable.SegmentedButtonGroup_divider, value))
+        {
+            if (value.type == TypedValue.TYPE_REFERENCE || value.type == TypedValue.TYPE_STRING)
+            {
                 // Note: Odd case where Android Studio layout preview editor will fail to display a
                 // SegmentedButtonGroup with a divider drawable because value.resourceId returns 0 and thus
                 // ContextCompat.getDrawable will return NullPointerException
                 // Loading drawable TypedArray.getDrawable or doing TypedArray.getResourceId fixes the problem
-                if (isInEditMode()) {
+                if (isInEditMode())
+                {
                     setDivider(ta.getDrawable(R.styleable.SegmentedButtonGroup_divider), dividerWidth, dividerRadius,
                             dividerPadding);
-                } else {
+                }
+                else
+                {
                     setDivider(ContextCompat.getDrawable(context, value.resourceId), dividerWidth, dividerRadius,
                             dividerPadding);
                 }
-            } else if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+            }
+            else if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT)
+            {
                 // Divider is a color, value.data is the color value
                 setDivider(value.data, dividerWidth, dividerRadius, dividerPadding);
-            } else {
+            }
+            else
+            {
                 // Invalid type for the divider, throw an exception
                 throw new IllegalArgumentException("Invalid type for SegmentedButtonGroup divider in layout XML "
                         + "resource. Must be a color or drawable");
@@ -358,9 +370,11 @@ public class SegmentedButtonGroup extends LinearLayout {
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
-    public void addView(View child, int index, ViewGroup.LayoutParams params) {
-        if (child instanceof SegmentedButton) {
-            final SegmentedButton button = (SegmentedButton) child;
+    public void addView(View child, int index, ViewGroup.LayoutParams params)
+    {
+        if (child instanceof SegmentedButton)
+        {
+            final SegmentedButton button = (SegmentedButton)child;
 
             // New position of the button will be the size of the buttons before the button is added
             // For example, if there are 5 buttons, then the indices are 0, 1, 2, 3, 4, so the next index is 5!
@@ -383,9 +397,11 @@ public class SegmentedButtonGroup extends LinearLayout {
 
                 // Find the first visible button to the left of this button (or null if none)
                 SegmentedButton leftButton = null;
-                for (int i = index1 - 1; i >= 0; --i) {
+                for (int i = index1 - 1; i >= 0; --i)
+                {
                     final SegmentedButton button_ = buttons.get(i);
-                    if (button_.getVisibility() != GONE) {
+                    if (button_.getVisibility() != GONE)
+                    {
                         leftButton = button_;
                         break;
                     }
@@ -393,9 +409,11 @@ public class SegmentedButtonGroup extends LinearLayout {
 
                 // Find the first visible button to the right of this button (or null if none)
                 SegmentedButton rightButton = null;
-                for (int i = index1 + 1; i < buttons.size(); ++i) {
+                for (int i = index1 + 1; i < buttons.size(); ++i)
+                {
                     final SegmentedButton button_ = buttons.get(i);
-                    if (button_.getVisibility() != GONE) {
+                    if (button_.getVisibility() != GONE)
+                    {
                         rightButton = button_;
                         break;
                     }
@@ -404,37 +422,44 @@ public class SegmentedButtonGroup extends LinearLayout {
                 // Below, we update the buttons leftButton and rightButton properties
                 // Think of the buttons in the group like a chain, each button knows about the button to the left and
                 // right of itself.
-                if (visibility == GONE) {
+                if (visibility == GONE)
+                {
                     // This button is being hidden, we leave the left/right button properties alone because they dont
                     // matter
                     //
                     // Update the "chain" of buttons so that the first visible left button is linked to the first
                     // visible right button
-                    if (leftButton != null) {
+                    if (leftButton != null)
+                    {
                         leftButton.setRightButton(rightButton);
                         leftButton.setupBackgroundClipPath();
                     }
 
                     // Update the "chain" of buttons so that the first visible right button is linked to the first
                     // visible left button
-                    if (rightButton != null) {
+                    if (rightButton != null)
+                    {
                         rightButton.setLeftButton(leftButton);
                         rightButton.setupBackgroundClipPath();
                     }
-                } else {
+                }
+                else
+                {
                     // This button is being shown again, we update the left/right button to be the first visible ones
                     button1.setLeftButton(leftButton);
                     button1.setRightButton(rightButton);
                     button1.setupBackgroundClipPath();
 
                     // Update the "chain" of buttons so that the left button points to this button now
-                    if (leftButton != null) {
+                    if (leftButton != null)
+                    {
                         leftButton.setRightButton(button1);
                         leftButton.setupBackgroundClipPath();
                     }
 
                     // Update the "chain" of buttons so that the right button points to this button now
-                    if (rightButton != null) {
+                    if (rightButton != null)
+                    {
                         rightButton.setLeftButton(button1);
                         rightButton.setupBackgroundClipPath();
                     }
@@ -445,22 +470,28 @@ public class SegmentedButtonGroup extends LinearLayout {
             // Otherwise disable ripple on the button if ripple is disabled
             // The ripple color is only passed to the buttons if a color is specified, otherwise the default color is
             // used from the button itself
-            if (ripple && hasRippleColor) {
+            if (ripple && hasRippleColor)
+            {
                 // Set button ripple color only if a value was given globally
                 button.setRipple(rippleColor);
-            } else if (!ripple) {
+            }
+            else if (!ripple)
+            {
                 // Disable the ripple on the button
                 button.setRipple(false);
             }
 
             // If this is NOT the first item in the group, then update the previous button and this button with its
             // respective right button and left button.
-            if (position != 0) {
+            if (position != 0)
+            {
                 // Find the first visible button to the left of this button (or null if none)
                 SegmentedButton leftButton = null;
-                for (int i = buttons.size() - 1; i >= 0; --i) {
+                for (int i = buttons.size() - 1; i >= 0; --i)
+                {
                     final SegmentedButton button_ = buttons.get(i);
-                    if (button_.getVisibility() != GONE) {
+                    if (button_.getVisibility() != GONE)
+                    {
                         leftButton = button_;
                         break;
                     }
@@ -468,7 +499,8 @@ public class SegmentedButtonGroup extends LinearLayout {
 
                 // If there is a visible button to the left, then set it to point to this button if its visible or
                 // otherwise null to treat it as an end button
-                if (leftButton != null) {
+                if (leftButton != null)
+                {
                     leftButton.setRightButton(button.getVisibility() != GONE ? button : null);
                     // Update background clip path for that button since it may need to add/remove round edges
                     leftButton.setupBackgroundClipPath();
@@ -490,9 +522,8 @@ public class SegmentedButtonGroup extends LinearLayout {
             buttons.add(button);
 
             // If the given position to start at is this button, select it
-            if (this.position == position) {
+            if (this.position == position)
                 updateSelectedPosition(position);
-            }
 
             // Add a divider view to the divider layout that mimics the size of the button
             // This view is used as essentially a spacer for the dividers in the divider layout
@@ -502,7 +533,9 @@ public class SegmentedButtonGroup extends LinearLayout {
             EmptyView dividerView = new EmptyView(getContext());
             dividerView.setVisibility(button.getVisibility());
             dividerLayout.addView(dividerView, params);
-        } else {
+        }
+        else
+        {
             // Not allowed to have children of any type besides SegmentedButton
             throw new IllegalArgumentException("Invalid child view for SegmentedButtonGroup. Only SegmentedButton's "
                     + "are valid children of the group");
@@ -522,18 +555,19 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @return int representing index of the corresponding button
      * @throws IllegalStateException if no button contains the coordinate within its bounds
      */
-    int getButtonPositionFromX(float x) {
+    int getButtonPositionFromX(float x)
+    {
         // Loop through each button
         int i = 0;
-        for (; i < buttons.size(); ++i) {
+        for (; i < buttons.size(); ++i)
+        {
             final SegmentedButton button = buttons.get(i);
 
             // If x value is less than the right-hand side of the button, this is the selected button
             // Note: No need to check the left side of button because we assume each button is directly connected
             // from left to right
-            if (button.getVisibility() != GONE && x <= button.getRight()) {
+            if (button.getVisibility() != GONE && x <= button.getRight())
                 break;
-            }
         }
 
         // Return last button if x value is out of bounds
@@ -554,22 +588,23 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @return float representing the fractional position of the corresponding button
      * @throws IllegalStateException if no button contains the coordinate within its bounds
      */
-    float getButtonPositionFromXF(float x) {
+    float getButtonPositionFromXF(float x)
+    {
         // Loop through each button
         int i = 0;
-        for (; i < buttons.size(); ++i) {
+        for (; i < buttons.size(); ++i)
+        {
             final SegmentedButton button = buttons.get(i);
 
             // If x value is less than the right-hand side of the button, this is the selected button
             // Note: No need to check the left side of button because we assume each button is directly connected
             // from left to right
-            if (button.getVisibility() != GONE && x < button.getRight()) {
+            if (button.getVisibility() != GONE && x < button.getRight())
                 return i + (x - button.getLeft()) / button.getWidth();
-            }
         }
 
         // Return last button if x value is out of bounds
-        return (float) i;
+        return (float)i;
     }
 
     /**
@@ -585,16 +620,18 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @hide
      */
     @Override
-    public boolean dispatchTouchEvent(final MotionEvent ev) {
+    public boolean dispatchTouchEvent(final MotionEvent ev)
+    {
         // Do not handle touch events if the view is disabled or not clickable
         // Oddly enough, the enabled and clickable states don't do anything unless specifically programmed into the
         // custom views
-        if (!isEnabled() || !isClickable()) {
+        if (!isEnabled() || !isClickable())
             return false;
-        }
 
-        switch (ev.getAction()) {
-            case MotionEvent.ACTION_UP: {
+        switch (ev.getAction())
+        {
+            case MotionEvent.ACTION_UP:
+            {
                 // Selected button position
                 final int position = getButtonPositionFromX(ev.getX());
 
@@ -609,13 +646,15 @@ public class SegmentedButtonGroup extends LinearLayout {
             }
             break;
 
-            case MotionEvent.ACTION_DOWN: {
+            case MotionEvent.ACTION_DOWN:
+            {
                 // Selected button position
                 final int position = getButtonPositionFromX(ev.getX());
 
                 // If button cannot be dragged, user is NOT pressing the currently selected button or the button is
                 // being animated, then just set drag offset to NaN meaning drag is not activated
-                if (!draggable || this.position != position || (buttonAnimator != null && buttonAnimator.isRunning())) {
+                if (!draggable || this.position != position || (buttonAnimator != null && buttonAnimator.isRunning()))
+                {
                     dragOffsetX = Float.NaN;
                     break;
                 }
@@ -638,11 +677,11 @@ public class SegmentedButtonGroup extends LinearLayout {
                 return true;
             }
 
-            case MotionEvent.ACTION_MOVE: {
+            case MotionEvent.ACTION_MOVE:
+            {
                 // Only drag if drag has been activated and hence is allowed
-                if (Float.isNaN(dragOffsetX)) {
+                if (Float.isNaN(dragOffsetX))
                     break;
-                }
 
                 // Get X coordinate of where the selected button should be by taking user's X location and subtract
                 // the offset
@@ -658,11 +697,13 @@ public class SegmentedButtonGroup extends LinearLayout {
             }
             break;
 
-            case MotionEvent.ACTION_CANCEL: {
+            case MotionEvent.ACTION_CANCEL:
+            {
                 // Cancel action is called when user leaves the view with their finger and another view captures the
                 // actions (e.g. scroll views for example)
                 // In this case, stop dragging and "snap" to nearest position
-                if (!Float.isNaN(dragOffsetX)) {
+                if (!Float.isNaN(dragOffsetX))
+                {
                     setPosition(Math.round(currentPosition), true);
 
                     // Enable scroll touch event interception again now that we're done dragging
@@ -685,7 +726,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * For example, a position of 2.25 would indicate that the selected button should START, i.e. the left side of
      * the selected button, at 1/4 of the width of the 3rd button.
      */
-    private void moveSelectedButton(final float position) {
+    private void moveSelectedButton(final float position)
+    {
         // Update current position to be the animated value
         // This is a float value indicating where the left-side of the button is located
         // For example, a currentPosition of 1.0 would mean all of button 1 was selected
@@ -695,14 +737,15 @@ public class SegmentedButtonGroup extends LinearLayout {
 
         // Get the current button position and extract the offset. For example, a currentPosition of 2.25 would
         // result in a currentButtonPosition of 2 and the currentOffset to 0.25.
-        final int currentButtonPosition = (int) currentPosition;
+        final int currentButtonPosition = (int)currentPosition;
         final float currentOffset = currentPosition - currentButtonPosition;
 
         // Get the current button end position, which will start at the current button plus 1 because the width of the
         // selected button is 1. Check each button to the right for the first one that is not GONE
         int currentEndButtonPosition = currentButtonPosition + 1;
         while (currentEndButtonPosition < buttons.size()
-                && buttons.get(currentEndButtonPosition).getVisibility() == GONE) {
+                && buttons.get(currentEndButtonPosition).getVisibility() == GONE)
+        {
             ++currentEndButtonPosition;
         }
 
@@ -719,7 +762,8 @@ public class SegmentedButtonGroup extends LinearLayout {
         // For the end button, we want to clip the left side of the button to match up with the right side of the
         // previous button. However, there is a slight chance the end button position might be out of range so we
         // check if it is first (do nothing if out of range, nothing to clip on left side of)
-        if (currentEndButtonPosition >= 0 && currentEndButtonPosition < buttons.size()) {
+        if (currentEndButtonPosition >= 0 && currentEndButtonPosition < buttons.size())
+        {
             // Grab the button directly to the right of the current button and clip the left
             final SegmentedButton currentEndButton = buttons.get(currentEndButtonPosition);
             currentEndButton.clipLeft(currentOffset);
@@ -732,7 +776,8 @@ public class SegmentedButtonGroup extends LinearLayout {
         // the end button position (where the selected button ends = currentButtonPosition + 1). If not equal, then
         // that means we are done showing the selected view on this button so we clip the entire view to just show
         // the normal button
-        if (lastPosition != currentButtonPosition && lastPosition != currentEndButtonPosition) {
+        if (lastPosition != currentButtonPosition && lastPosition != currentEndButtonPosition)
+        {
             buttons.get(lastPosition).clipRight(1.0f);
         }
 
@@ -740,15 +785,15 @@ public class SegmentedButtonGroup extends LinearLayout {
         // is the next VISIBLE button, so we start at 1 plus the last position because the width of the selected button
         // is 1
         int lastEndPosition = lastPosition + 1;
-        while (lastEndPosition < buttons.size() && buttons.get(lastEndPosition).getVisibility() == GONE) {
+        while (lastEndPosition < buttons.size() && buttons.get(lastEndPosition).getVisibility() == GONE)
+        {
             ++lastEndPosition;
         }
 
         // Clip any views like explained above
         if (lastEndPosition != currentEndButtonPosition && lastEndPosition != currentButtonPosition
-                && lastEndPosition < buttons.size()) {
+                && lastEndPosition < buttons.size())
             buttons.get(lastEndPosition).clipRight(1.0f);
-        }
 
         // Update the lastPosition for the next animation frame
         lastPosition = currentButtonPosition;
@@ -766,29 +811,33 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * In addition, the onPositionChangedListener will be called with the updated position.
      */
-    private void updateSelectedPosition(final int position) {
+    private void updateSelectedPosition(final int position)
+    {
         // Update position, current position and last position to the desired value
         this.position = position;
         this.currentPosition = position;
         this.lastPosition = position;
 
         // Loop through each button and reset it to the appropriate value
-        for (int i = 0; i < buttons.size(); ++i) {
+        for (int i = 0; i < buttons.size(); ++i)
+        {
             final SegmentedButton button = buttons.get(i);
 
-            if (i == position) {
+            if (i == position)
+            {
                 // Show entire selected view
                 button.clipRight(0.0f);
-            } else {
+            }
+            else
+            {
                 // Hide entire selected view
                 button.clipRight(1.0f);
             }
         }
 
         // Notify listener of position change
-        if (onPositionChangedListener != null) {
+        if (onPositionChangedListener != null)
             onPositionChangedListener.onPositionChanged(position);
-        }
     }
 
     // endregion
@@ -796,7 +845,8 @@ public class SegmentedButtonGroup extends LinearLayout {
     // region Save & Restore State
 
     @Override
-    protected Parcelable onSaveInstanceState() {
+    protected Parcelable onSaveInstanceState()
+    {
         Bundle bundle = new Bundle();
         bundle.putParcelable("superState", super.onSaveInstanceState());
 
@@ -807,15 +857,17 @@ public class SegmentedButtonGroup extends LinearLayout {
     }
 
     @Override
-    protected void onRestoreInstanceState(final Parcelable state) {
+    protected void onRestoreInstanceState(final Parcelable state)
+    {
         // On off chance that the state is not a Bundle, just pass it to the parent class
         // Not sure why this would ever happen, but prevents a casting exception
-        if (!(state instanceof Bundle)) {
+        if (!(state instanceof Bundle))
+        {
             super.onRestoreInstanceState(state);
             return;
         }
 
-        final Bundle bundle = (Bundle) state;
+        final Bundle bundle = (Bundle)state;
 
         // Restore position of selected button
         final int position = bundle.getInt("position");
@@ -831,7 +883,8 @@ public class SegmentedButtonGroup extends LinearLayout {
     /**
      * List of segmented buttons that are attached to this button group
      */
-    public ArrayList<SegmentedButton> getButtons() {
+    public ArrayList<SegmentedButton> getButtons()
+    {
         return buttons;
     }
 
@@ -840,7 +893,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * Segmented buttons are indexed according to their order of being added to this group
      */
-    public SegmentedButton getButton(int index) {
+    public SegmentedButton getButton(int index)
+    {
         return buttons.get(index);
     }
 
@@ -855,7 +909,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @return the current background drawable when the button is not selected
      */
-    public Drawable getBackground() {
+    public Drawable getBackground()
+    {
         return backgroundDrawable;
     }
 
@@ -867,14 +922,15 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param drawable drawable to set the background to
      */
     @Override
-    public void setBackground(final Drawable drawable) {
+    public void setBackground(final Drawable drawable)
+    {
         backgroundDrawable = drawable;
 
         // Check for non-null buttons because parent class calls setBackground
-        if (buttons != null) {
-            for (SegmentedButton button : buttons) {
+        if (buttons != null)
+        {
+            for (SegmentedButton button : buttons)
                 button.setBackground(drawable);
-            }
         }
     }
 
@@ -887,13 +943,17 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param color color to set the background to
      */
-    public void setBackground(@ColorInt int color) {
-        if (backgroundDrawable instanceof ColorDrawable) {
-            ((ColorDrawable) backgroundDrawable.mutate()).setColor(color);
+    public void setBackground(@ColorInt int color)
+    {
+        if (backgroundDrawable instanceof ColorDrawable)
+        {
+            ((ColorDrawable)backgroundDrawable.mutate()).setColor(color);
 
             // Required to update background for the buttons
             setBackground(backgroundDrawable);
-        } else {
+        }
+        else
+        {
             setBackground(new ColorDrawable(color));
         }
     }
@@ -908,7 +968,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @see #setBackground(int)
      */
     @Override
-    public void setBackgroundColor(@ColorInt int color) {
+    public void setBackgroundColor(@ColorInt int color)
+    {
         setBackground(color);
     }
 
@@ -923,7 +984,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @return the current background drawable when the button is selected
      */
-    public Drawable getSelectedBackground() {
+    public Drawable getSelectedBackground()
+    {
         return selectedBackgroundDrawable;
     }
 
@@ -934,12 +996,12 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param drawable drawable to set the background to
      */
-    public void setSelectedBackground(final Drawable drawable) {
+    public void setSelectedBackground(final Drawable drawable)
+    {
         selectedBackgroundDrawable = drawable;
 
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
             button.setSelectedBackground(drawable);
-        }
     }
 
     /**
@@ -951,13 +1013,17 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param color color to set the background to
      */
-    public void setSelectedBackground(@ColorInt int color) {
-        if (selectedBackgroundDrawable instanceof ColorDrawable) {
-            ((ColorDrawable) selectedBackgroundDrawable.mutate()).setColor(color);
+    public void setSelectedBackground(@ColorInt int color)
+    {
+        if (selectedBackgroundDrawable instanceof ColorDrawable)
+        {
+            ((ColorDrawable)selectedBackgroundDrawable.mutate()).setColor(color);
 
             // Required to update background for the buttons
             setSelectedBackground(selectedBackgroundDrawable);
-        } else {
+        }
+        else
+        {
             setSelectedBackground(new ColorDrawable(color));
         }
     }
@@ -968,7 +1034,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param color color to set the background to
      * @see #setSelectedBackground(int)
      */
-    public void setSelectedBackgroundColor(@ColorInt int color) {
+    public void setSelectedBackgroundColor(@ColorInt int color)
+    {
         setSelectedBackground(color);
     }
 
@@ -977,14 +1044,16 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * 0px value indicates no border is present
      */
-    public int getBorderWidth() {
+    public int getBorderWidth()
+    {
         return borderWidth;
     }
 
     /**
      * Return color of the border
      */
-    public int getBorderColor() {
+    public int getBorderColor()
+    {
         return borderColor;
     }
 
@@ -993,7 +1062,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * 0px value indicates the border is solid
      */
-    public int getBorderDashWidth() {
+    public int getBorderDashWidth()
+    {
         return borderDashWidth;
     }
 
@@ -1002,7 +1072,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * Only relevant if border dash width is greater than 0px
      */
-    public int getBorderDashGap() {
+    public int getBorderDashGap()
+    {
         return borderDashGap;
     }
 
@@ -1014,14 +1085,16 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param dashWidth Width of the dash for border, in pixels. Value of 0px means solid line (default is 0px)
      * @param dashGap   Width of the gap for border, in pixels.
      */
-    public void setBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
+    public void setBorder(int width, @ColorInt int color, int dashWidth, int dashGap)
+    {
         borderWidth = width;
         borderColor = color;
         borderDashWidth = dashWidth;
         borderDashGap = dashGap;
 
         // Border width of 0 indicates to hide borders
-        if (width > 0) {
+        if (width > 0)
+        {
             GradientDrawable borderDrawable = new GradientDrawable();
             // Set background color to be transparent so that buttons and everything underneath the border view is
             // still visible. This was an issue on API 16 Android where it would default to a black background
@@ -1033,7 +1106,9 @@ public class SegmentedButtonGroup extends LinearLayout {
             borderDrawable.setStroke(width, color, dashWidth, dashGap);
 
             borderView.setBackground(borderDrawable);
-        } else {
+        }
+        else
+        {
             borderView.setBackground(null);
         }
     }
@@ -1043,14 +1118,16 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * 0px value indicates no border is present
      */
-    public int getSelectedBorderWidth() {
+    public int getSelectedBorderWidth()
+    {
         return selectedBorderWidth;
     }
 
     /**
      * Return color of the border for the selected button
      */
-    public int getSelectedBorderColor() {
+    public int getSelectedBorderColor()
+    {
         return selectedBorderColor;
     }
 
@@ -1059,7 +1136,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * 0px value indicates the border is solid
      */
-    public int getSelectedBorderDashWidth() {
+    public int getSelectedBorderDashWidth()
+    {
         return selectedBorderDashWidth;
     }
 
@@ -1068,7 +1146,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * Only relevant if border dash width is greater than 0px
      */
-    public int getSelectedBorderDashGap() {
+    public int getSelectedBorderDashGap()
+    {
         return selectedBorderDashGap;
     }
 
@@ -1080,16 +1159,16 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param dashWidth Width of the dash for border, in pixels. Value of 0px means solid line (default is 0px)
      * @param dashGap   Width of the gap for border, in pixels.
      */
-    public void setSelectedBorder(int width, @ColorInt int color, int dashWidth, int dashGap) {
+    public void setSelectedBorder(int width, @ColorInt int color, int dashWidth, int dashGap)
+    {
         selectedBorderWidth = width;
         selectedBorderColor = color;
         selectedBorderDashWidth = dashWidth;
         selectedBorderDashGap = dashGap;
 
         // Loop through each button and set the selected button border
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
             button.setSelectedButtonBorder(width, color, dashWidth, dashGap);
-        }
     }
 
     /**
@@ -1097,7 +1176,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * A value of 0px indicates the view is rectangular and has no rounded corners
      */
-    public int getRadius() {
+    public int getRadius()
+    {
         return radius;
     }
 
@@ -1106,11 +1186,13 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param radius value of new corner radius, in pixels
      */
-    public void setRadius(final int radius) {
+    public void setRadius(final int radius)
+    {
         this.radius = radius;
 
         // Update radius for each button
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
+        {
             button.setBackgroundRadius(radius);
             button.setupBackgroundClipPath();
 
@@ -1118,15 +1200,13 @@ public class SegmentedButtonGroup extends LinearLayout {
         }
 
         // Update border for new radius
-        GradientDrawable borderDrawable = (GradientDrawable) borderView.getBackground();
-        if (borderDrawable != null) {
+        GradientDrawable borderDrawable = (GradientDrawable)borderView.getBackground();
+        if (borderDrawable != null)
             borderDrawable.setCornerRadius(radius - borderWidth / 2.0f);
-        }
 
         // Invalidate shadow outline so that it will be updated to follow the new radius
-        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)
             invalidateOutline();
-        }
     }
 
     /**
@@ -1134,7 +1214,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * A value of 0px indicates the selected button will be rectangular and has no rounded corners
      */
-    public int getSelectedButtonRadius() {
+    public int getSelectedButtonRadius()
+    {
         return selectedButtonRadius;
     }
 
@@ -1143,11 +1224,13 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param selectedButtonRadius value of the new selected button corner radius, in pixels
      */
-    public void setSelectedButtonRadius(int selectedButtonRadius) {
+    public void setSelectedButtonRadius(int selectedButtonRadius)
+    {
         this.selectedButtonRadius = selectedButtonRadius;
 
         // Update the selected button radius for each button
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
+        {
             button.setSelectedButtonRadius(selectedButtonRadius);
             button.setupSelectedButtonClipPath();
         }
@@ -1159,7 +1242,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * If the button is currently being animated, then the position will be the old button position until the
      * animation is complete
      */
-    public int getPosition() {
+    public int getPosition()
+    {
         return position;
     }
 
@@ -1181,7 +1265,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param position index of new button to select
      * @param animate  whether or not to animate moving to the button
      */
-    public void setPosition(final int position, final boolean animate) {
+    public void setPosition(final int position, final boolean animate)
+    {
         // Return and do nothing in two cases
         // First, if the position is out of bounds.
         // Second, if the desired position is equal to the current position do nothing. But, only do this under two
@@ -1190,12 +1275,12 @@ public class SegmentedButtonGroup extends LinearLayout {
         // Also if the user is not dragging the button. If the user lets go from dragging and the button is still on
         // the same position but slightly offset, then we want to snap back to normal.
         if (position < 0 || position >= buttons.size() || (position == this.position && (buttonAnimator != null
-                && !buttonAnimator.isRunning()) && Float.isNaN(dragOffsetX))) {
+                && !buttonAnimator.isRunning()) && Float.isNaN(dragOffsetX)))
             return;
-        }
 
         // If not animating or if the animation interpolator is null, then just update the selected position
-        if (!animate || selectionAnimationInterpolator == null) {
+        if (!animate || selectionAnimationInterpolator == null)
+        {
             updateSelectedPosition(position);
             return;
         }
@@ -1204,17 +1289,20 @@ public class SegmentedButtonGroup extends LinearLayout {
         // GONE. Add to a list for later
         final List<Integer> buttonGoneIndices = new ArrayList<>();
         final boolean movingRight = currentPosition < position;
-        if (movingRight) {
-            for (int i = (int) Math.ceil(currentPosition); i < position; ++i) {
-                if (buttons.get(i).getVisibility() == GONE) {
+        if (movingRight)
+        {
+            for (int i = (int)Math.ceil(currentPosition); i < position; ++i)
+            {
+                if (buttons.get(i).getVisibility() == GONE)
                     buttonGoneIndices.add(i);
-                }
             }
-        } else {
-            for (int i = (int) Math.floor(currentPosition); i > position; --i) {
-                if (buttons.get(i).getVisibility() == GONE) {
+        }
+        else
+        {
+            for (int i = (int)Math.floor(currentPosition); i > position; --i)
+            {
+                if (buttons.get(i).getVisibility() == GONE)
                     buttonGoneIndices.add(i + 1);
-                }
             }
         }
 
@@ -1228,17 +1316,17 @@ public class SegmentedButtonGroup extends LinearLayout {
 
         // For each update to the animation value, move the button
         buttonAnimator.addUpdateListener(animation -> {
-            float value = (float) animation.getAnimatedValue();
+            float value = (float)animation.getAnimatedValue();
 
             // Account for GONE buttons in between the indices
             // Depending on if we're moving left/right, we add/subtract one when a button is missing
             // This will skip the GONE button
-            for (int index : buttonGoneIndices) {
-                if (movingRight && value >= index) {
+            for (int index : buttonGoneIndices)
+            {
+                if (movingRight && value >= index)
                     value += 1;
-                } else if (!movingRight && value <= index) {
+                else if (!movingRight && value <= index)
                     value -= 1;
-                }
             }
 
             // Move to the new position
@@ -1248,9 +1336,11 @@ public class SegmentedButtonGroup extends LinearLayout {
         // Set the parameters for the button animation
         buttonAnimator.setDuration(selectionAnimationDuration);
         buttonAnimator.setInterpolator(selectionAnimationInterpolator);
-        buttonAnimator.addListener(new AnimatorListenerAdapter() {
+        buttonAnimator.addListener(new AnimatorListenerAdapter()
+        {
             @Override
-            public void onAnimationEnd(final Animator animation) {
+            public void onAnimationEnd(final Animator animation)
+            {
                 // Update the position of the button at the end of the animation
                 // Also resets all buttons to their appropriate state in case the animation went wrong in any way
                 updateSelectedPosition(position);
@@ -1268,7 +1358,8 @@ public class SegmentedButtonGroup extends LinearLayout {
     /**
      * Returns whether or not the currently selected button can be moved via dragging
      */
-    public boolean isDraggable() {
+    public boolean isDraggable()
+    {
         return draggable;
     }
 
@@ -1279,7 +1370,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * selected button will follow the users finger. When the user lets go, the selected button will snap to the
      * nearest button
      */
-    public void setDraggable(final boolean draggable) {
+    public void setDraggable(final boolean draggable)
+    {
         this.draggable = draggable;
     }
 
@@ -1289,7 +1381,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * If false, then no animation will be shown if the user taps a button. Otherwise, if true a ripple effect will
      * be shown on button tap.
      */
-    public boolean hasRipple() {
+    public boolean hasRipple()
+    {
         return ripple;
     }
 
@@ -1298,7 +1391,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * The ripple color is a tint color applied on top of the button when it is pressed
      */
-    public int getRippleColor() {
+    public int getRippleColor()
+    {
         return rippleColor;
     }
 
@@ -1310,13 +1404,13 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param enabled whether or not to enable the ripple effect for all buttons in the group
      */
-    public void setRipple(final boolean enabled) {
+    public void setRipple(final boolean enabled)
+    {
         ripple = enabled;
 
         // Loop through and set the ripple for each button
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
             button.setRipple(enabled);
-        }
     }
 
     /**
@@ -1326,20 +1420,21 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param color color to set for the ripple effect for all buttons in the group
      */
-    public void setRipple(final @ColorInt int color) {
+    public void setRipple(final @ColorInt int color)
+    {
         ripple = true;
         rippleColor = color;
 
         // Loop through and set the ripple color for each button
-        for (SegmentedButton button : buttons) {
+        for (SegmentedButton button : buttons)
             button.setRipple(color);
-        }
     }
 
     /**
      * Returns divider drawable that is placed between each button in the group, value of null indicates no drawable
      */
-    public Drawable getDivider() {
+    public Drawable getDivider()
+    {
         return dividerLayout.getDividerDrawable();
     }
 
@@ -1353,9 +1448,11 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param radius   corner radius of the divider drawable to round the corners, in pixels
      * @param padding  space above and below the divider drawable within the button group, in pixels
      */
-    public void setDivider(@Nullable Drawable drawable, int width, int radius, int padding) {
+    public void setDivider(@Nullable Drawable drawable, int width, int radius, int padding)
+    {
         // Drawable of null indicates that we want to hide dividers
-        if (drawable == null) {
+        if (drawable == null)
+        {
             dividerLayout.setDividerDrawable(null);
             dividerLayout.setShowDividers(SHOW_DIVIDER_NONE);
             return;
@@ -1363,13 +1460,16 @@ public class SegmentedButtonGroup extends LinearLayout {
 
         // Set the corner radius and size if the drawable is a GradientDrawable
         // Otherwise just set the divider drawable like normal because we cant set the parameters
-        if (drawable instanceof GradientDrawable) {
-            GradientDrawable gradient = (GradientDrawable) drawable;
+        if (drawable instanceof GradientDrawable)
+        {
+            GradientDrawable gradient = (GradientDrawable)drawable;
             gradient.setSize(width, 0);
             gradient.setCornerRadius(radius);
 
             dividerLayout.setDividerDrawable(gradient);
-        } else {
+        }
+        else
+        {
             dividerLayout.setDividerDrawable(drawable);
         }
 
@@ -1385,11 +1485,12 @@ public class SegmentedButtonGroup extends LinearLayout {
      * @param radius  corner radius of the divider drawable to round the corners, in pixels
      * @param padding space above and below the divider drawable within the button group, in pixels
      */
-    public void setDivider(@ColorInt int color, int width, int radius, int padding) {
+    public void setDivider(@ColorInt int color, int width, int radius, int padding)
+    {
         // Create GradientDrawable of the specified color
         // This is used to specify the corner radius, unlike ColorDrawable that does not have that feature
         GradientDrawable drawable = new GradientDrawable(GradientDrawable.Orientation.BOTTOM_TOP,
-                new int[]{color, color});
+                new int[] {color, color});
 
         drawable.setCornerRadius(radius);
         drawable.setShape(GradientDrawable.RECTANGLE);
@@ -1405,7 +1506,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * This will return null if no animation is being used
      */
-    public Interpolator getSelectionAnimationInterpolator() {
+    public Interpolator getSelectionAnimationInterpolator()
+    {
         return selectionAnimationInterpolator;
     }
 
@@ -1414,7 +1516,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * If interpolator is null, no animation will be used
      */
-    public void setSelectionAnimationInterpolator(@Nullable Interpolator interpolator) {
+    public void setSelectionAnimationInterpolator(@Nullable Interpolator interpolator)
+    {
         selectionAnimationInterpolator = interpolator;
     }
 
@@ -1425,8 +1528,10 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param interpolator int value indicating which predefined Android interpolator to use
      */
-    public void setSelectionAnimationInterpolator(@AnimationInterpolator int interpolator) {
-        switch (interpolator) {
+    public void setSelectionAnimationInterpolator(@AnimationInterpolator int interpolator)
+    {
+        switch (interpolator)
+        {
             case ANIM_INTERPOLATOR_NONE:
                 selectionAnimationInterpolator = null;
                 break;
@@ -1484,7 +1589,8 @@ public class SegmentedButtonGroup extends LinearLayout {
     /**
      * Return the duration, in milliseconds, it takes to complete the animation to change selected button
      */
-    public int getSelectionAnimationDuration() {
+    public int getSelectionAnimationDuration()
+    {
         return selectionAnimationDuration;
     }
 
@@ -1493,21 +1599,24 @@ public class SegmentedButtonGroup extends LinearLayout {
      *
      * @param selectionAnimationDuration duration in milliseconds for animation to complete
      */
-    public void setSelectionAnimationDuration(final int selectionAnimationDuration) {
+    public void setSelectionAnimationDuration(final int selectionAnimationDuration)
+    {
         this.selectionAnimationDuration = selectionAnimationDuration;
     }
 
     /**
      * Returns the listener used for notifying position changes
      */
-    public OnPositionChangedListener getOnPositionChangedListener() {
+    public OnPositionChangedListener getOnPositionChangedListener()
+    {
         return onPositionChangedListener;
     }
 
     /**
      * Sets the listeners used for notifying position changes
      */
-    public void setOnPositionChangedListener(final OnPositionChangedListener onPositionChangedListener) {
+    public void setOnPositionChangedListener(final OnPositionChangedListener onPositionChangedListener)
+    {
         this.onPositionChangedListener = onPositionChangedListener;
     }
 
@@ -1521,8 +1630,8 @@ public class SegmentedButtonGroup extends LinearLayout {
      * This callback will be called AFTER the animation is complete since the position does not change until the
      * completion of the animation.
      */
-    public interface OnPositionChangedListener {
-
+    public interface OnPositionChangedListener
+    {
         void onPositionChanged(int position);
     }
 
@@ -1538,10 +1647,11 @@ public class SegmentedButtonGroup extends LinearLayout {
      * same API.
      */
     @RequiresApi(api = VERSION_CODES.LOLLIPOP)
-    private class OutlineProvider extends ViewOutlineProvider {
-
+    private class OutlineProvider extends ViewOutlineProvider
+    {
         @Override
-        public void getOutline(final View view, final Outline outline) {
+        public void getOutline(final View view, final Outline outline)
+        {
             outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), radius);
         }
     }

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButtonGroup.java
@@ -72,11 +72,11 @@ public class SegmentedButtonGroup extends LinearLayout
     // of the valid values
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({
-            ANIM_INTERPOLATOR_NONE, ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN, ANIM_INTERPOLATOR_BOUNCE,
-            ANIM_INTERPOLATOR_LINEAR, ANIM_INTERPOLATOR_DECELERATE, ANIM_INTERPOLATOR_CYCLE,
-            ANIM_INTERPOLATOR_ANTICIPATE, ANIM_INTERPOLATOR_ACCELERATE_DECELERATE, ANIM_INTERPOLATOR_ACCELERATE,
-            ANIM_INTERPOLATOR_ANTICIPATE_OVERSHOOT, ANIM_INTERPOLATOR_FAST_OUT_LINEAR_IN,
-            ANIM_INTERPOLATOR_LINEAR_OUT_SLOW_IN, ANIM_INTERPOLATOR_OVERSHOOT
+        ANIM_INTERPOLATOR_NONE, ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN, ANIM_INTERPOLATOR_BOUNCE,
+        ANIM_INTERPOLATOR_LINEAR, ANIM_INTERPOLATOR_DECELERATE, ANIM_INTERPOLATOR_CYCLE,
+        ANIM_INTERPOLATOR_ANTICIPATE, ANIM_INTERPOLATOR_ACCELERATE_DECELERATE, ANIM_INTERPOLATOR_ACCELERATE,
+        ANIM_INTERPOLATOR_ANTICIPATE_OVERSHOOT, ANIM_INTERPOLATOR_FAST_OUT_LINEAR_IN,
+        ANIM_INTERPOLATOR_LINEAR_OUT_SLOW_IN, ANIM_INTERPOLATOR_OVERSHOOT
     })
     public @interface AnimationInterpolator {}
 
@@ -228,12 +228,12 @@ public class SegmentedButtonGroup extends LinearLayout
         // Call super addView so that we do not trigger an Exception since only SegmentedButton instances can be
         // added to this view
         super.addView(container, -1, new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                LayoutParams.MATCH_PARENT));
+            LayoutParams.MATCH_PARENT));
 
         // Layout that contains all SegmentedButton's
         buttonLayout = new LinearLayout(getContext());
         buttonLayout.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                LayoutParams.WRAP_CONTENT));
+            LayoutParams.WRAP_CONTENT));
         buttonLayout.setOrientation(LinearLayout.HORIZONTAL);
         container.addView(buttonLayout);
 
@@ -242,7 +242,7 @@ public class SegmentedButtonGroup extends LinearLayout
         // top of them
         borderView = new EmptyView(context);
         borderView.setLayoutParams(new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT));
+            ViewGroup.LayoutParams.MATCH_PARENT));
         container.addView(borderView);
 
         // Create layout that contains dividers for each button
@@ -254,7 +254,7 @@ public class SegmentedButtonGroup extends LinearLayout
         // buttonLayout
         dividerLayout = new LinearLayout(getContext());
         dividerLayout.setLayoutParams(new FrameLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                LayoutParams.MATCH_PARENT));
+            LayoutParams.MATCH_PARENT));
         dividerLayout.setOrientation(LinearLayout.HORIZONTAL);
         dividerLayout.setClickable(false);
         dividerLayout.setFocusable(false);
@@ -334,12 +334,12 @@ public class SegmentedButtonGroup extends LinearLayout
                 if (isInEditMode())
                 {
                     setDivider(ta.getDrawable(R.styleable.SegmentedButtonGroup_divider), dividerWidth, dividerRadius,
-                            dividerPadding);
+                        dividerPadding);
                 }
                 else
                 {
                     setDivider(ContextCompat.getDrawable(context, value.resourceId), dividerWidth, dividerRadius,
-                            dividerPadding);
+                        dividerPadding);
                 }
             }
             else if (value.type >= TypedValue.TYPE_FIRST_COLOR_INT && value.type <= TypedValue.TYPE_LAST_COLOR_INT)
@@ -351,12 +351,12 @@ public class SegmentedButtonGroup extends LinearLayout
             {
                 // Invalid type for the divider, throw an exception
                 throw new IllegalArgumentException("Invalid type for SegmentedButtonGroup divider in layout XML "
-                        + "resource. Must be a color or drawable");
+                    + "resource. Must be a color or drawable");
             }
         }
 
         int selectionAnimationInterpolator = ta.getInt(R.styleable.SegmentedButtonGroup_selectionAnimationInterpolator,
-                ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN);
+            ANIM_INTERPOLATOR_FAST_OUT_SLOW_IN);
         setSelectionAnimationInterpolator(selectionAnimationInterpolator);
         selectionAnimationDuration = ta.getInt(R.styleable.SegmentedButtonGroup_selectionAnimationDuration, 500);
 
@@ -515,7 +515,7 @@ public class SegmentedButtonGroup extends LinearLayout
             button.setupBackgroundClipPath();
             button.setupSelectedButtonClipPath();
             button.setSelectedButtonBorder(selectedBorderWidth, selectedBorderColor, selectedBorderDashWidth,
-                    selectedBorderDashGap);
+                selectedBorderDashGap);
 
             // Add the button to the main group instead and store the button in our buttons list
             buttonLayout.addView(button, params);
@@ -527,18 +527,21 @@ public class SegmentedButtonGroup extends LinearLayout
 
             // Add a divider view to the divider layout that mimics the size of the button
             // This view is used as essentially a spacer for the dividers in the divider layout
-            // TODO If layout_weight is not used then the alignment of the dividers are off, need to subtract
-            // dividerWidth from the width to center them.
-            // TODO Divider not appropriately aligned for wrap_content, need to find a handler to update the layout on
-            EmptyView dividerView = new EmptyView(getContext());
+            // The divider view needs to know the divider width in order to offset the width correctly
+            ButtonActor dividerView = new ButtonActor(getContext());
+            dividerView.setButton(button);
+            dividerView.setLayoutParams(new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
             dividerView.setVisibility(button.getVisibility());
-            dividerLayout.addView(dividerView, params);
+            Drawable dividerDrawable = dividerLayout.getDividerDrawable();
+            if (dividerDrawable != null)
+                dividerView.setDividerWidth(dividerDrawable.getIntrinsicWidth());
+            dividerLayout.addView(dividerView);
         }
         else
         {
             // Not allowed to have children of any type besides SegmentedButton
             throw new IllegalArgumentException("Invalid child view for SegmentedButtonGroup. Only SegmentedButton's "
-                    + "are valid children of the group");
+                + "are valid children of the group");
         }
     }
 
@@ -744,7 +747,7 @@ public class SegmentedButtonGroup extends LinearLayout
         // selected button is 1. Check each button to the right for the first one that is not GONE
         int currentEndButtonPosition = currentButtonPosition + 1;
         while (currentEndButtonPosition < buttons.size()
-                && buttons.get(currentEndButtonPosition).getVisibility() == GONE)
+            && buttons.get(currentEndButtonPosition).getVisibility() == GONE)
         {
             ++currentEndButtonPosition;
         }
@@ -792,7 +795,7 @@ public class SegmentedButtonGroup extends LinearLayout
 
         // Clip any views like explained above
         if (lastEndPosition != currentEndButtonPosition && lastEndPosition != currentButtonPosition
-                && lastEndPosition < buttons.size())
+            && lastEndPosition < buttons.size())
             buttons.get(lastEndPosition).clipRight(1.0f);
 
         // Update the lastPosition for the next animation frame
@@ -1275,7 +1278,7 @@ public class SegmentedButtonGroup extends LinearLayout
         // Also if the user is not dragging the button. If the user lets go from dragging and the button is still on
         // the same position but slightly offset, then we want to snap back to normal.
         if (position < 0 || position >= buttons.size() || (position == this.position && (buttonAnimator != null
-                && !buttonAnimator.isRunning()) && Float.isNaN(dragOffsetX)))
+            && !buttonAnimator.isRunning()) && Float.isNaN(dragOffsetX)))
             return;
 
         // If not animating or if the animation interpolator is null, then just update the selected position
@@ -1312,7 +1315,7 @@ public class SegmentedButtonGroup extends LinearLayout
         //
         // The new position is adjusted to remove GONE buttons
         buttonAnimator = ValueAnimator.ofFloat(currentPosition,
-                movingRight ? position - buttonGoneIndices.size() : position + buttonGoneIndices.size());
+            movingRight ? position - buttonGoneIndices.size() : position + buttonGoneIndices.size());
 
         // For each update to the animation value, move the button
         buttonAnimator.addUpdateListener(animation -> {
@@ -1475,6 +1478,14 @@ public class SegmentedButtonGroup extends LinearLayout
 
         dividerLayout.setDividerPadding(padding);
         dividerLayout.setShowDividers(SHOW_DIVIDER_MIDDLE);
+
+        // Loop through and update the divider width for each of the dummy divider views
+        for (int i = 0; i < dividerLayout.getChildCount(); ++i)
+        {
+            final ButtonActor view = (ButtonActor)dividerLayout.getChildAt(i);
+            view.setDividerWidth(width);
+        }
+        dividerLayout.requestLayout();
     }
 
     /**
@@ -1490,7 +1501,7 @@ public class SegmentedButtonGroup extends LinearLayout
         // Create GradientDrawable of the specified color
         // This is used to specify the corner radius, unlike ColorDrawable that does not have that feature
         GradientDrawable drawable = new GradientDrawable(GradientDrawable.Orientation.BOTTOM_TOP,
-                new int[] {color, color});
+            new int[] {color, color});
 
         drawable.setCornerRadius(radius);
         drawable.setShape(GradientDrawable.RECTANGLE);
@@ -1499,6 +1510,14 @@ public class SegmentedButtonGroup extends LinearLayout
         dividerLayout.setDividerDrawable(drawable);
         dividerLayout.setDividerPadding(padding);
         dividerLayout.setShowDividers(SHOW_DIVIDER_MIDDLE);
+
+        // Loop through and update the divider width for each of the dummy divider views
+        for (int i = 0; i < dividerLayout.getChildCount(); ++i)
+        {
+            final ButtonActor view = (ButtonActor)dividerLayout.getChildAt(i);
+            view.setDividerWidth(width);
+        }
+        dividerLayout.requestLayout();
     }
 
     /**

--- a/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
+++ b/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
@@ -3,7 +3,9 @@ package com.addisonelliott.segmentedbutton.sample;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
@@ -11,7 +13,10 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.LinearLayout.LayoutParams;
 import android.widget.Spinner;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import butterknife.BindView;
@@ -24,7 +29,8 @@ import com.addisonelliott.segmentedbutton.sample.drawable.BadgeDrawable;
 import java.util.ArrayList;
 import java.util.Random;
 
-enum Action {
+enum Action
+{
     None,
     ChangeBorder1,
     ChangeBorder2,
@@ -52,104 +58,163 @@ enum Action {
     ChangeSelectedButtonBorderDashed,
     ToggleHiddenButtons;
 
-    public String getDisplayText() {
-        if (this == None) {
+    public String getDisplayText()
+    {
+        if (this == None)
+        {
             return "";
-        } else if (this == ChangeBorder1) {
+        }
+        else if (this == ChangeBorder1)
+        {
             return "Change border 1";
-        } else if (this == ChangeBorder2) {
+        }
+        else if (this == ChangeBorder2)
+        {
             return "Change border 2";
-        } else if (this == ChangeBackgroundColor) {
+        }
+        else if (this == ChangeBackgroundColor)
+        {
             return "Change background and selected background to color";
-        } else if (this == ChangeBackgroundDrawable) {
+        }
+        else if (this == ChangeBackgroundDrawable)
+        {
             return "Change background and selected background to drawable";
-        } else if (this == ChangeRadius) {
+        }
+        else if (this == ChangeRadius)
+        {
             return "Change radius";
-        } else if (this == ChangePositionAnimated) {
+        }
+        else if (this == ChangePositionAnimated)
+        {
             return "Change position and animate movement";
-        } else if (this == ChangePosition) {
+        }
+        else if (this == ChangePosition)
+        {
             return "Change position without animating";
-        } else if (this == ToggleDraggable) {
+        }
+        else if (this == ToggleDraggable)
+        {
             return "Toggle draggable boolean";
-        } else if (this == ToggleRipple) {
+        }
+        else if (this == ToggleRipple)
+        {
             return "Toggle ripple";
-        } else if (this == ToggleRippleColor) {
+        }
+        else if (this == ToggleRippleColor)
+        {
             return "Toggle ripple color between black/white";
-        } else if (this == ChangeDivider) {
+        }
+        else if (this == ChangeDivider)
+        {
             return "Change divider";
-        } else if (this == ChangeAnimation) {
+        }
+        else if (this == ChangeAnimation)
+        {
             return "Change animation duration & interpolator";
-        } else if (this == RemoveButtonDrawable) {
+        }
+        else if (this == RemoveButtonDrawable)
+        {
             return "Remove button drawable";
-        } else if (this == ChangeButtonDrawable) {
+        }
+        else if (this == ChangeButtonDrawable)
+        {
             return "Change button drawable";
-        } else if (this == ChangeDrawableTint) {
+        }
+        else if (this == ChangeDrawableTint)
+        {
             return "Change drawable tint color";
-        } else if (this == ToggleDrawableSize) {
+        }
+        else if (this == ToggleDrawableSize)
+        {
             return "Toggle drawable size";
-        } else if (this == ChangeDrawableGravity) {
+        }
+        else if (this == ChangeDrawableGravity)
+        {
             return "Change drawable gravity";
-        } else if (this == ChangeText) {
+        }
+        else if (this == ChangeText)
+        {
             return "Change text";
-        } else if (this == ChangeTextColor) {
+        }
+        else if (this == ChangeTextColor)
+        {
             return "Change text color";
-        } else if (this == ChangeTextSize) {
+        }
+        else if (this == ChangeTextSize)
+        {
             return "Change text size";
-        } else if (this == ChangeTypeface) {
+        }
+        else if (this == ChangeTypeface)
+        {
             return "Change typeface";
-        } else if (this == ChangeSelectedButtonRadius) {
+        }
+        else if (this == ChangeSelectedButtonRadius)
+        {
             return "Change selected button radius";
-        } else if (this == ChangeSelectedButtonBorderSolid) {
+        }
+        else if (this == ChangeSelectedButtonBorderSolid)
+        {
             return "Change selected button border (solid)";
-        } else if (this == ChangeSelectedButtonBorderDashed) {
+        }
+        else if (this == ChangeSelectedButtonBorderDashed)
+        {
             return "Change selected button border (dashed)";
-        } else if (this == ToggleHiddenButtons) {
+        }
+        else if (this == ToggleHiddenButtons)
+        {
             return "Toggle hidden buttons";
-        } else {
+        }
+        else
+        {
             return "";
         }
     }
 }
 
-public class MainActivity extends AppCompatActivity implements OnItemSelectedListener {
-
+public class MainActivity extends AppCompatActivity implements OnItemSelectedListener
+{
     private static final String TAG = "SegmentedButtonSample";
 
-    @BindView(R.id.spinner)
-    Spinner spinner;
-    @BindView(R.id.button_changePosition)
-    Button changePositionButton;
-    @BindView(R.id.buttonGroup_gradient)
-    SegmentedButtonGroup gradientButtonGroup;
-    @BindView(R.id.buttonGroup_lordOfTheRings)
-    SegmentedButtonGroup lordOfTheRingsButtonGroup;
-    @BindView(R.id.buttonGroup_DCSuperheros)
-    SegmentedButtonGroup DCSuperHerosButtonGroup;
-    @BindView(R.id.buttonGroup_marvelSuperheros)
-    SegmentedButtonGroup marvelSuperherosButtonGroup;
-    @BindView(R.id.buttonGroup_guys)
-    SegmentedButtonGroup guysButtonGroup;
-    @BindView(R.id.buttonGroup_starWars)
-    SegmentedButtonGroup starWarsButtonGroup;
-    @BindView(R.id.buttonGroup_darthVader)
-    SegmentedButtonGroup darthVaderButtonGroup;
-    @BindView(R.id.buttonGroup_draggable)
-    SegmentedButtonGroup draggableButtonGroup;
-    @BindView(R.id.buttonGroup_dynamic)
-    SegmentedButtonGroup dynamicButtonGroup;
-    @BindView(R.id.button_left)
-    SegmentedButton leftButton;
-    @BindView(R.id.button_right)
-    SegmentedButton rightButton;
-    @BindView(R.id.buttonGroup_pickupDropoffBoth)
-    SegmentedButtonGroup pickupDropoffButtonGroup;
-    @BindView(R.id.buttonGroup_starWarsAlt)
-    SegmentedButtonGroup starWarsAltButtonGroup;
-    @BindView(R.id.buttonGroup_roundSelectedButton)
-    SegmentedButtonGroup roundSelectedButtonGroup;
+    @BindView(R.id.linearLayout)
+    LinearLayout linearLayout;
+//    @BindView(R.id.spinner)
+//    Spinner spinner;
+//    @BindView(R.id.button_changePosition)
+//    Button changePositionButton;
+//    @BindView(R.id.buttonGroup_gradient)
+//    SegmentedButtonGroup gradientButtonGroup;
+//    @BindView(R.id.buttonGroup_lordOfTheRings)
+//    SegmentedButtonGroup lordOfTheRingsButtonGroup;
+//    @BindView(R.id.buttonGroup_DCSuperheros)
+//    SegmentedButtonGroup DCSuperHerosButtonGroup;
+//    @BindView(R.id.buttonGroup_marvelSuperheros)
+//    SegmentedButtonGroup marvelSuperherosButtonGroup;
+//    @BindView(R.id.buttonGroup_guys)
+//    SegmentedButtonGroup guysButtonGroup;
+//    @BindView(R.id.buttonGroup_starWars)
+//    SegmentedButtonGroup starWarsButtonGroup;
+//    @BindView(R.id.buttonGroup_darthVader)
+//    SegmentedButtonGroup darthVaderButtonGroup;
+//    @BindView(R.id.buttonGroup_draggable)
+//    SegmentedButtonGroup draggableButtonGroup;
+//    @BindView(R.id.buttonGroup_dynamic)
+//    SegmentedButtonGroup dynamicButtonGroup;
+//    @BindView(R.id.button_left)
+//    SegmentedButton leftButton;
+//    @BindView(R.id.button_right)
+//    SegmentedButton rightButton;
+//    @BindView(R.id.buttonGroup_pickupDropoffBoth)
+//    SegmentedButtonGroup pickupDropoffButtonGroup;
+//    @BindView(R.id.buttonGroup_starWarsAlt)
+//    SegmentedButtonGroup starWarsAltButtonGroup;
+//    @BindView(R.id.buttonGroup_roundSelectedButton)
+//    SegmentedButtonGroup roundSelectedButtonGroup;
+
+    SegmentedButtonGroup yesNoMaybePButtonGroup;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState)
+    {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
@@ -158,249 +223,422 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
 
         ArrayList<String> spinnerItems = new ArrayList<>();
 
-        for (Action action : Action.values()) {
+        for (Action action : Action.values())
+        {
             spinnerItems.add(action.getDisplayText());
         }
 
         ArrayAdapter adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, spinnerItems);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinner.setAdapter(adapter);
-        spinner.setOnItemSelectedListener(this);
+//        spinner.setAdapter(adapter);
+//        spinner.setOnItemSelectedListener(this);
+//
+//        updateButton(gradientButtonGroup.getPosition());
+//        gradientButtonGroup.setOnPositionChangedListener(position -> updateButton(position));
 
-        updateButton(gradientButtonGroup.getPosition());
-        gradientButtonGroup.setOnPositionChangedListener(position -> updateButton(position));
+//        setupDynamicDrawables();
+        setupYesNoMaybeButtonGroup();
 
-        setupDynamicDrawables();
-
-        // Basic checks
-        if (starWarsButtonGroup.getButtons().size() != 3) {
-            throw new AssertionError("Buttons size incorrect");
-        }
-
-        if (!lordOfTheRingsButtonGroup.getButton(1).getText().equals("Gimli")) {
-            throw new AssertionError("Button name is incorrect");
-        }
+//        // Basic checks
+//        if (starWarsButtonGroup.getButtons().size() != 3)
+//        {
+//            throw new AssertionError("Buttons size incorrect");
+//        }
+//
+//        if (!lordOfTheRingsButtonGroup.getButton(1).getText().equals("Gimli"))
+//        {
+//            throw new AssertionError("Button name is incorrect");
+//        }
     }
 
     @Override
-    public void onItemSelected(final AdapterView<?> parent, final View view, final int position, final long id) {
+    public void onItemSelected(final AdapterView<?> parent, final View view, final int position, final long id)
+    {
         Action action = Action.values()[position];
 
-        switch (action) {
+        switch (action)
+        {
             case None:
                 break;
 
-            case ChangeBorder1:
-                lordOfTheRingsButtonGroup.setBorder(5, Color.RED, 25, 8);
-                marvelSuperherosButtonGroup.setBorder(5, Color.BLACK, 30, 10);
-                break;
-
-            case ChangeBorder2:
-                lordOfTheRingsButtonGroup.setBorder(2, Color.RED, 25, 8);
-                marvelSuperherosButtonGroup.setBorder(2, Color.BLACK, 30, 10);
-                break;
-
-            case ChangeBackgroundColor:
-                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getColor(getApplicationContext(),
-                        R.color.brown_600));
-                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getColor(getApplicationContext(),
-                        R.color.blue_800));
-                break;
-
-            case ChangeBackgroundDrawable:
-                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getDrawable(getApplicationContext(),
-                        R.drawable.gradient_drawable));
-                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getDrawable(getApplicationContext(),
-                        R.drawable.gradient_drawable_selector));
-                break;
-
-            case ChangeRadius:
-                marvelSuperherosButtonGroup.setRadius(5);
-                DCSuperHerosButtonGroup.setRadius(50);
-                break;
-
-            case ChangePositionAnimated:
-                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), true);
-                break;
-
-            case ChangePosition:
-                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), false);
-                break;
-
-            case ToggleDraggable:
-                darthVaderButtonGroup.setDraggable(!darthVaderButtonGroup.isDraggable());
-                break;
-
-            case ToggleRipple:
-                starWarsButtonGroup.setRipple(!starWarsButtonGroup.hasRipple());
-                break;
-
-            case ToggleRippleColor:
-                starWarsButtonGroup.setRipple(starWarsButtonGroup.getRippleColor() == Color.WHITE ? Color.BLACK :
-                        Color.WHITE);
-                break;
-
-            case ChangeDivider:
-                lordOfTheRingsButtonGroup.setDivider(Color.MAGENTA, 10, 10, 10);
-                guysButtonGroup.setDivider(ContextCompat.getDrawable(getApplicationContext(),
-                        R.drawable.gradient_drawable_divider), 20, 0, 0);
-                break;
-
-            case ChangeAnimation:
-                lordOfTheRingsButtonGroup.setSelectionAnimationDuration(
-                        lordOfTheRingsButtonGroup.getSelectionAnimationDuration() == 500 ? 5000 : 500);
-
-                final int random = new Random().nextInt(12);
-                lordOfTheRingsButtonGroup.setSelectionAnimationInterpolator(random);
-                break;
-
-            case RemoveButtonDrawable:
-                lordOfTheRingsButtonGroup.getButton(0).setDrawable(null);
-                break;
-
-            case ChangeButtonDrawable:
-                lordOfTheRingsButtonGroup.getButton(0).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
-                        R.drawable.ic_b9));
-                DCSuperHerosButtonGroup.getButton(1).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
-                        R.drawable.ic_aragorn));
-                break;
-
-            case ChangeDrawableTint:
-                lordOfTheRingsButtonGroup.getButton(0).setSelectedDrawableTint(Color.RED);
-                lordOfTheRingsButtonGroup.getButton(1).setDrawableTint(Color.GREEN);
-                lordOfTheRingsButtonGroup.getButton(2).setDrawableTint(Color.BLUE);
-                darthVaderButtonGroup.getButton(1).removeDrawableTint();
-                break;
-
-            case ToggleDrawableSize:
-                final boolean setSize = !DCSuperHerosButtonGroup.getButton(0).hasDrawableWidth();
-                final float size = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 96.0f,
-                        getApplicationContext().getResources().getDisplayMetrics());
-
-                for (SegmentedButton button : DCSuperHerosButtonGroup.getButtons()) {
-                    button.setDrawableWidth(setSize ? (int) size : -1);
-                    button.setDrawableHeight(setSize ? (int) size : -1);
-                }
-                break;
-
-            case ChangeDrawableGravity:
-                gradientButtonGroup.getButton(0).setDrawableGravity(Gravity.LEFT);
-                starWarsButtonGroup.getButton(0).setDrawableGravity(Gravity.RIGHT);
-
-                int currentGravity = DCSuperHerosButtonGroup.getButton(0).getDrawableGravity();
-
-                switch (currentGravity) {
-                    case Gravity.LEFT:
-                        currentGravity = Gravity.TOP;
-                        break;
-                    case Gravity.TOP:
-                        currentGravity = Gravity.RIGHT;
-                        break;
-                    case Gravity.RIGHT:
-                        currentGravity = Gravity.BOTTOM;
-                        break;
-                    case Gravity.BOTTOM:
-                        currentGravity = Gravity.LEFT;
-                        break;
-                }
-
-                DCSuperHerosButtonGroup.getButton(0).setDrawableGravity(currentGravity);
-                break;
-
-            case ChangeText:
-                lordOfTheRingsButtonGroup.getButton(0).setText("Testing");
-                lordOfTheRingsButtonGroup.getButton(1).setText("");
-                break;
-
-            case ChangeTextColor:
-                lordOfTheRingsButtonGroup.getButton(0).setSelectedTextColor(Color.RED);
-                lordOfTheRingsButtonGroup.getButton(1).setTextColor(Color.BLUE);
-                gradientButtonGroup.getButton(1).removeSelectedTextColor();
-                break;
-
-            case ChangeTextSize:
-                lordOfTheRingsButtonGroup.getButton(1).setTextSize(48.0f);
-                DCSuperHerosButtonGroup.getButton(0).setTextSize(48.0f);
-                break;
-
-            case ChangeTypeface:
-                lordOfTheRingsButtonGroup.getButton(0).setTextTypeface(Typeface.create((Typeface) null, Typeface.BOLD));
-                break;
-
-            case ChangeSelectedButtonRadius: {
-                final float radius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30.0f,
-                        getApplicationContext().getResources().getDisplayMetrics());
-
-                lordOfTheRingsButtonGroup.setSelectedButtonRadius((int) radius);
-                roundSelectedButtonGroup.setSelectedButtonRadius(0);
-            }
-            break;
-
-            case ChangeSelectedButtonBorderSolid:
-                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 0, 0);
-                roundSelectedButtonGroup.setSelectedBorder(0, 0, 0, 0);
-                break;
-
-            case ChangeSelectedButtonBorderDashed:
-                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 6, 3);
-                roundSelectedButtonGroup.setSelectedBorder(16, Color.BLACK, 6, 2);
-                break;
-
-            case ToggleHiddenButtons: {
-                SegmentedButton button = gradientButtonGroup.getButton(0);
-                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-
-                button = starWarsButtonGroup.getButton(1);
-                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-
-                button = darthVaderButtonGroup.getButton(2);
-                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-
-                button = draggableButtonGroup.getButton(0);
-                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-
-                button = roundSelectedButtonGroup.getButton(2);
-                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-            }
-            break;
+//            case ChangeBorder1:
+//                lordOfTheRingsButtonGroup.setBorder(5, Color.RED, 25, 8);
+//                marvelSuperherosButtonGroup.setBorder(5, Color.BLACK, 30, 10);
+//                break;
+//
+//            case ChangeBorder2:
+//                lordOfTheRingsButtonGroup.setBorder(2, Color.RED, 25, 8);
+//                marvelSuperherosButtonGroup.setBorder(2, Color.BLACK, 30, 10);
+//                break;
+//
+//            case ChangeBackgroundColor:
+//                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getColor(getApplicationContext(),
+//                        R.color.brown_600));
+//                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getColor(getApplicationContext(),
+//                        R.color.blue_800));
+//                break;
+//
+//            case ChangeBackgroundDrawable:
+//                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getDrawable(getApplicationContext(),
+//                        R.drawable.gradient_drawable));
+//                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getDrawable(getApplicationContext(),
+//                        R.drawable.gradient_drawable_selector));
+//                break;
+//
+//            case ChangeRadius:
+//                marvelSuperherosButtonGroup.setRadius(5);
+//                DCSuperHerosButtonGroup.setRadius(50);
+//                break;
+//
+//            case ChangePositionAnimated:
+//                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), true);
+//                break;
+//
+//            case ChangePosition:
+//                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), false);
+//                break;
+//
+//            case ToggleDraggable:
+//                darthVaderButtonGroup.setDraggable(!darthVaderButtonGroup.isDraggable());
+//                break;
+//
+//            case ToggleRipple:
+//                starWarsButtonGroup.setRipple(!starWarsButtonGroup.hasRipple());
+//                break;
+//
+//            case ToggleRippleColor:
+//                starWarsButtonGroup.setRipple(starWarsButtonGroup.getRippleColor() == Color.WHITE ? Color.BLACK :
+//                        Color.WHITE);
+//                break;
+//
+//            case ChangeDivider:
+//                lordOfTheRingsButtonGroup.setDivider(Color.MAGENTA, 10, 10, 10);
+//                guysButtonGroup.setDivider(ContextCompat.getDrawable(getApplicationContext(),
+//                        R.drawable.gradient_drawable_divider), 20, 0, 0);
+//                break;
+//
+//            case ChangeAnimation:
+//                lordOfTheRingsButtonGroup.setSelectionAnimationDuration(
+//                        lordOfTheRingsButtonGroup.getSelectionAnimationDuration() == 500 ? 5000 : 500);
+//
+//                final int random = new Random().nextInt(12);
+//                lordOfTheRingsButtonGroup.setSelectionAnimationInterpolator(random);
+//                break;
+//
+//            case RemoveButtonDrawable:
+//                lordOfTheRingsButtonGroup.getButton(0).setDrawable(null);
+//                break;
+//
+//            case ChangeButtonDrawable:
+//                lordOfTheRingsButtonGroup.getButton(0).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
+//                        R.drawable.ic_b9));
+//                DCSuperHerosButtonGroup.getButton(1).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
+//                        R.drawable.ic_aragorn));
+//                break;
+//
+//            case ChangeDrawableTint:
+//                lordOfTheRingsButtonGroup.getButton(0).setSelectedDrawableTint(Color.RED);
+//                lordOfTheRingsButtonGroup.getButton(1).setDrawableTint(Color.GREEN);
+//                lordOfTheRingsButtonGroup.getButton(2).setDrawableTint(Color.BLUE);
+//                darthVaderButtonGroup.getButton(1).removeDrawableTint();
+//                break;
+//
+//            case ToggleDrawableSize:
+//                final boolean setSize = !DCSuperHerosButtonGroup.getButton(0).hasDrawableWidth();
+//                final float size = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 96.0f,
+//                        getApplicationContext().getResources().getDisplayMetrics());
+//
+//                for (SegmentedButton button : DCSuperHerosButtonGroup.getButtons())
+//                {
+//                    button.setDrawableWidth(setSize ? (int)size : -1);
+//                    button.setDrawableHeight(setSize ? (int)size : -1);
+//                }
+//                break;
+//
+//            case ChangeDrawableGravity:
+//                gradientButtonGroup.getButton(0).setDrawableGravity(Gravity.LEFT);
+//                starWarsButtonGroup.getButton(0).setDrawableGravity(Gravity.RIGHT);
+//
+//                int currentGravity = DCSuperHerosButtonGroup.getButton(0).getDrawableGravity();
+//
+//                switch (currentGravity)
+//                {
+//                    case Gravity.LEFT:
+//                        currentGravity = Gravity.TOP;
+//                        break;
+//                    case Gravity.TOP:
+//                        currentGravity = Gravity.RIGHT;
+//                        break;
+//                    case Gravity.RIGHT:
+//                        currentGravity = Gravity.BOTTOM;
+//                        break;
+//                    case Gravity.BOTTOM:
+//                        currentGravity = Gravity.LEFT;
+//                        break;
+//                }
+//
+//                DCSuperHerosButtonGroup.getButton(0).setDrawableGravity(currentGravity);
+//                break;
+//
+//            case ChangeText:
+//                lordOfTheRingsButtonGroup.getButton(0).setText("Testing");
+//                lordOfTheRingsButtonGroup.getButton(1).setText("");
+//                break;
+//
+//            case ChangeTextColor:
+//                lordOfTheRingsButtonGroup.getButton(0).setSelectedTextColor(Color.RED);
+//                lordOfTheRingsButtonGroup.getButton(1).setTextColor(Color.BLUE);
+//                gradientButtonGroup.getButton(1).removeSelectedTextColor();
+//                break;
+//
+//            case ChangeTextSize:
+//                lordOfTheRingsButtonGroup.getButton(1).setTextSize(48.0f);
+//                DCSuperHerosButtonGroup.getButton(0).setTextSize(48.0f);
+//                break;
+//
+//            case ChangeTypeface:
+//                lordOfTheRingsButtonGroup.getButton(0).setTextTypeface(Typeface.create((Typeface)null, Typeface.BOLD));
+//                break;
+//
+//            case ChangeSelectedButtonRadius:
+//            {
+//                final float radius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30.0f,
+//                        getApplicationContext().getResources().getDisplayMetrics());
+//
+//                lordOfTheRingsButtonGroup.setSelectedButtonRadius((int)radius);
+//                roundSelectedButtonGroup.setSelectedButtonRadius(0);
+//            }
+//            break;
+//
+//            case ChangeSelectedButtonBorderSolid:
+//                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 0, 0);
+//                roundSelectedButtonGroup.setSelectedBorder(0, 0, 0, 0);
+//                break;
+//
+//            case ChangeSelectedButtonBorderDashed:
+//                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 6, 3);
+//                roundSelectedButtonGroup.setSelectedBorder(16, Color.BLACK, 6, 2);
+//                break;
+//
+//            case ToggleHiddenButtons:
+//            {
+//                SegmentedButton button = gradientButtonGroup.getButton(0);
+//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+//
+//                button = starWarsButtonGroup.getButton(1);
+//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+//
+//                button = darthVaderButtonGroup.getButton(2);
+//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+//
+//                button = draggableButtonGroup.getButton(0);
+//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+//
+//                button = roundSelectedButtonGroup.getButton(2);
+//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+//            }
+//            break;
 
             default:
                 break;
         }
 
         // Reset back to the normal value
-        spinner.setSelection(0);
+//        spinner.setSelection(0);
     }
 
     @Override
-    public void onNothingSelected(final AdapterView<?> parent) {
+    public void onNothingSelected(final AdapterView<?> parent)
+    {
 
     }
 
-    @OnClick(R.id.button_changePosition)
-    public void changePositionButton_onClick(View view) {
-        int position = gradientButtonGroup.getPosition();
-        position = ++position % 3;
-        updateButton(position);
+//    @OnClick(R.id.button_changePosition)
+//    public void changePositionButton_onClick(View view)
+//    {
+//        int position = gradientButtonGroup.getPosition();
+//        position = ++position % 3;
+//        updateButton(position);
+//
+//        gradientButtonGroup.setPosition(position, true);
+//    }
+//
+//    private void setupDynamicDrawables()
+//    {
+//        final BadgeDrawable drawable = new BadgeDrawable(Color.RED, 80, 50, 3, 3);
+//        leftButton.setDrawable(drawable);
+//
+//        dynamicButtonGroup.setOnPositionChangedListener(position -> {
+//            if (position == 0)
+//            {
+//                drawable.setCount(drawable.getCount() + 1);
+//            }
+//        });
+//
+//        final Drawable drawable2 = ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_b1);
+//        rightButton.setDrawable(drawable2);
+//    }
+//
+//    private void updateButton(int position)
+//    {
+//        changePositionButton.setText("Position: " + position);
+//    }
 
-        gradientButtonGroup.setPosition(position, true);
+    private float dpToPx(float dp)
+    {
+        return dp * getResources().getDisplayMetrics().density;
     }
 
-    private void setupDynamicDrawables() {
-        final BadgeDrawable drawable = new BadgeDrawable(Color.RED, 80, 50, 3, 3);
-        leftButton.setDrawable(drawable);
+    private float pxToDp(float px)
+    {
+        return px / getResources().getDisplayMetrics().density;
+    }
 
-        dynamicButtonGroup.setOnPositionChangedListener(position -> {
-            if (position == 0) {
-                drawable.setCount(drawable.getCount() + 1);
+    private float spToPx(float sp)
+    {
+        return sp * getResources().getDisplayMetrics().scaledDensity;
+    }
+
+    private float pxToSp(float px)
+    {
+        return px / getResources().getDisplayMetrics().scaledDensity;
+    }
+
+    @RequiresApi(api = VERSION_CODES.LOLLIPOP)
+    private void setupYesNoMaybeButtonGroup()
+    {
+        // TODO Recreate some of the button groups in the layout manually to ensure they work the same
+        //  Once I get a few examples working, play around with the example given to me
+
+        SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
+        buttonGroup.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+        ((LinearLayout.LayoutParams)buttonGroup.getLayoutParams()).setMargins((int)dpToPx(4), (int)dpToPx(4),
+                (int)dpToPx(4), (int)dpToPx(4));
+        buttonGroup.setElevation(dpToPx(2));
+        buttonGroup.setBackground(Color.WHITE);
+        buttonGroup.setRadius((int)dpToPx(30));
+        buttonGroup.setRipple(Color.BLACK);
+        buttonGroup.setSelectedBackground(getResources().getColor(R.color.blue_500));
+        buttonGroup.setSelectedBorder((int)dpToPx(2), Color.rgb(0x55, 0x55, 0x55), 0, 0);
+        buttonGroup.setSelectedButtonRadius((int)dpToPx(30));
+        buttonGroup.setSelectionAnimationDuration(1000);
+        buttonGroup.setOnPositionChangedListener(position -> {
+            if (yesNoMaybePButtonGroup == null)
+                return;
+
+            Log.v(TAG,
+                    "Button sizes: " + yesNoMaybePButtonGroup.getButton(0).getWidth() + " "
+                            + yesNoMaybePButtonGroup.getButton(1).getWidth() + " "
+                            + yesNoMaybePButtonGroup.getButton(2).getWidth());
+
+            // TODO This fixes the problem
+
+            // TODO requestLayout() -> That is what causes the buttons to relayout and correct size
+            // The size of the text was still updated however
+            for (int i = 0; i < 3; ++i)
+            {
+                SegmentedButton button = yesNoMaybePButtonGroup.getButton(i);
+                button.setText(button.getText());
             }
         });
 
-        final Drawable drawable2 = ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_b1);
-        rightButton.setDrawable(drawable2);
-    }
+        Log.v("SegmentedButton", "Start creation");
 
-    private void updateButton(int position) {
-        changePositionButton.setText("Position: " + position);
+        SegmentedButton yesButton = new SegmentedButton(this);
+        yesButton.setText("Yes");
+        yesButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
+        yesButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        yesButton.setTextColor(Color.BLACK);
+        yesButton.setSelectedTextColor(Color.WHITE);
+        yesButton.setTextSize(spToPx(24));
+        buttonGroup.addView(yesButton);
+
+        SegmentedButton maybeButton = new SegmentedButton(this);
+        maybeButton.setText("Maybe");
+        maybeButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
+        maybeButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        maybeButton.setTextColor(Color.BLACK);
+        maybeButton.setSelectedTextColor(Color.WHITE);
+        maybeButton.setTextSize(spToPx(24));
+        buttonGroup.addView(maybeButton);
+
+        SegmentedButton noButton = new SegmentedButton(this);
+        noButton.setText("No");
+        noButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
+        noButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        noButton.setTextColor(Color.BLACK);
+        noButton.setSelectedTextColor(Color.WHITE);
+        noButton.setTextSize(spToPx(24));
+        buttonGroup.addView(noButton);
+
+        buttonGroup.setPosition(1, false);
+
+        linearLayout.addView(buttonGroup);
+        yesNoMaybePButtonGroup = buttonGroup;
+
+        Log.v("SegmentedButton", "End creation");
+
+//        SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
+//        buttonGroup.setBorder(3, Color.LTGRAY, 0, 0);
+//
+//        String[] names = {
+//                "Two",
+//                "One",
+//                "None"
+//        };
+//
+//        buttonGroup.setOnPositionChangedListener(position -> {
+//            for (String name : names) {
+//
+//            }
+//        });
+//
+//        for (String name : names) {
+//            SegmentedButton button = new SegmentedButton(this);
+//            button.setText(name);
+//            button.setTextSize(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 96.0f,
+//                    getResources().getDisplayMetrics()));
+//            button.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, 1.0));
+//            button.setPadding(16, 16, 16, 16);
+//            button.setTextColor(Color.BLACK);
+//            button.setSelectedTextColor(Color.BLACK);
+//            buttonGroup.addView(button);
+//        }
+
+//        buttonGroup.setOnPositionChangedListener(new
+//                                                         SegmentedButtonGroup.OnPositionChangedListener() {
+//                                                             @Override
+//                                                             public void onPositionChanged(final int position) {
+//                                                                 if (doneSetup) {
+//                                                                     for (int i = 0; i < valnams.size(); i++) {
+//                                                                         segButArray.get(num).getButton(i)
+//                                                                                 .setSelectedTextColor(Color.WHITE);
+//                                                                         segButArray.get(num).getButton(i)
+//                                                                                 .setSelectedBackgroundColor(
+//                                                                                         getResources().getColor(
+//                                                                                                 R.color.colorPrimary));
+//                                                                     }
+//                                                                     clicked(num, position);
+//                                                                 }
+//                                                             }
+//                                                         });
+//
+//        segButArray.add(buttonGroup);
+//        LayoutParams segLayoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+//        segLayoutParams.setMargins(32, 16, 32, 16);
+//
+//        for (int i = 0; i < valnams.size(); i++) {
+//            SegmentedButton rb = new SegmentedButton(ctx);
+//
+//            rb.setText(valnams.get(i));
+//            rb.setTextSize(Globals.convertDpToPixel(18));
+//            rb.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, (float) 1.0));
+//            rb.setPadding(16, 16, 16, 16);
+//            rb.setTextColor(Color.BLACK);
+//            rb.setSelectedTextColor(Color.BLACK);
+//            buttonGroup.addView(rb);
+//        }
+//
+//        layout.addView(buttonGroup, segLayoutParams);
     }
 }

--- a/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
+++ b/sample/src/main/java/com/addisonelliott/segmentedbutton/sample/MainActivity.java
@@ -3,10 +3,9 @@ package com.addisonelliott.segmentedbutton.sample;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
-import android.util.Log;
-import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
@@ -16,7 +15,6 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.Spinner;
-import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import butterknife.BindView;
@@ -24,7 +22,6 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.addisonelliott.segmentedbutton.SegmentedButton;
 import com.addisonelliott.segmentedbutton.SegmentedButtonGroup;
-import com.addisonelliott.segmentedbutton.SegmentedButtonGroup.OnPositionChangedListener;
 import com.addisonelliott.segmentedbutton.sample.drawable.BadgeDrawable;
 import java.util.ArrayList;
 import java.util.Random;
@@ -56,118 +53,67 @@ enum Action
     ChangeSelectedButtonRadius,
     ChangeSelectedButtonBorderSolid,
     ChangeSelectedButtonBorderDashed,
-    ToggleHiddenButtons;
+    ToggleHiddenButtons,
+    ChangeTextSize2;
 
     public String getDisplayText()
     {
         if (this == None)
-        {
             return "";
-        }
         else if (this == ChangeBorder1)
-        {
             return "Change border 1";
-        }
         else if (this == ChangeBorder2)
-        {
             return "Change border 2";
-        }
         else if (this == ChangeBackgroundColor)
-        {
             return "Change background and selected background to color";
-        }
         else if (this == ChangeBackgroundDrawable)
-        {
             return "Change background and selected background to drawable";
-        }
         else if (this == ChangeRadius)
-        {
             return "Change radius";
-        }
         else if (this == ChangePositionAnimated)
-        {
             return "Change position and animate movement";
-        }
         else if (this == ChangePosition)
-        {
             return "Change position without animating";
-        }
         else if (this == ToggleDraggable)
-        {
             return "Toggle draggable boolean";
-        }
         else if (this == ToggleRipple)
-        {
             return "Toggle ripple";
-        }
         else if (this == ToggleRippleColor)
-        {
             return "Toggle ripple color between black/white";
-        }
         else if (this == ChangeDivider)
-        {
             return "Change divider";
-        }
         else if (this == ChangeAnimation)
-        {
             return "Change animation duration & interpolator";
-        }
         else if (this == RemoveButtonDrawable)
-        {
             return "Remove button drawable";
-        }
         else if (this == ChangeButtonDrawable)
-        {
             return "Change button drawable";
-        }
         else if (this == ChangeDrawableTint)
-        {
             return "Change drawable tint color";
-        }
         else if (this == ToggleDrawableSize)
-        {
             return "Toggle drawable size";
-        }
         else if (this == ChangeDrawableGravity)
-        {
             return "Change drawable gravity";
-        }
         else if (this == ChangeText)
-        {
             return "Change text";
-        }
         else if (this == ChangeTextColor)
-        {
             return "Change text color";
-        }
         else if (this == ChangeTextSize)
-        {
             return "Change text size";
-        }
         else if (this == ChangeTypeface)
-        {
             return "Change typeface";
-        }
         else if (this == ChangeSelectedButtonRadius)
-        {
             return "Change selected button radius";
-        }
         else if (this == ChangeSelectedButtonBorderSolid)
-        {
             return "Change selected button border (solid)";
-        }
         else if (this == ChangeSelectedButtonBorderDashed)
-        {
             return "Change selected button border (dashed)";
-        }
         else if (this == ToggleHiddenButtons)
-        {
             return "Toggle hidden buttons";
-        }
+        else if (this == ChangeTextSize2)
+            return "Change Text Size 2";
         else
-        {
             return "";
-        }
     }
 }
 
@@ -177,40 +123,42 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
 
     @BindView(R.id.linearLayout)
     LinearLayout linearLayout;
-//    @BindView(R.id.spinner)
-//    Spinner spinner;
-//    @BindView(R.id.button_changePosition)
-//    Button changePositionButton;
-//    @BindView(R.id.buttonGroup_gradient)
-//    SegmentedButtonGroup gradientButtonGroup;
-//    @BindView(R.id.buttonGroup_lordOfTheRings)
-//    SegmentedButtonGroup lordOfTheRingsButtonGroup;
-//    @BindView(R.id.buttonGroup_DCSuperheros)
-//    SegmentedButtonGroup DCSuperHerosButtonGroup;
-//    @BindView(R.id.buttonGroup_marvelSuperheros)
-//    SegmentedButtonGroup marvelSuperherosButtonGroup;
-//    @BindView(R.id.buttonGroup_guys)
-//    SegmentedButtonGroup guysButtonGroup;
-//    @BindView(R.id.buttonGroup_starWars)
-//    SegmentedButtonGroup starWarsButtonGroup;
-//    @BindView(R.id.buttonGroup_darthVader)
-//    SegmentedButtonGroup darthVaderButtonGroup;
-//    @BindView(R.id.buttonGroup_draggable)
-//    SegmentedButtonGroup draggableButtonGroup;
-//    @BindView(R.id.buttonGroup_dynamic)
-//    SegmentedButtonGroup dynamicButtonGroup;
-//    @BindView(R.id.button_left)
-//    SegmentedButton leftButton;
-//    @BindView(R.id.button_right)
-//    SegmentedButton rightButton;
-//    @BindView(R.id.buttonGroup_pickupDropoffBoth)
-//    SegmentedButtonGroup pickupDropoffButtonGroup;
-//    @BindView(R.id.buttonGroup_starWarsAlt)
-//    SegmentedButtonGroup starWarsAltButtonGroup;
-//    @BindView(R.id.buttonGroup_roundSelectedButton)
-//    SegmentedButtonGroup roundSelectedButtonGroup;
+    @BindView(R.id.spinner)
+    Spinner spinner;
+    @BindView(R.id.button_changePosition)
+    Button changePositionButton;
+    @BindView(R.id.buttonGroup_gradient)
+    SegmentedButtonGroup gradientButtonGroup;
+    @BindView(R.id.buttonGroup_lordOfTheRings)
+    SegmentedButtonGroup lordOfTheRingsButtonGroup;
+    @BindView(R.id.buttonGroup_DCSuperheros)
+    SegmentedButtonGroup DCSuperHerosButtonGroup;
+    @BindView(R.id.buttonGroup_marvelSuperheros)
+    SegmentedButtonGroup marvelSuperherosButtonGroup;
+    @BindView(R.id.buttonGroup_guys)
+    SegmentedButtonGroup guysButtonGroup;
+    @BindView(R.id.buttonGroup_starWars)
+    SegmentedButtonGroup starWarsButtonGroup;
+    @BindView(R.id.buttonGroup_darthVader)
+    SegmentedButtonGroup darthVaderButtonGroup;
+    @BindView(R.id.buttonGroup_draggable)
+    SegmentedButtonGroup draggableButtonGroup;
+    @BindView(R.id.buttonGroup_dynamic)
+    SegmentedButtonGroup dynamicButtonGroup;
+    @BindView(R.id.button_left)
+    SegmentedButton leftButton;
+    @BindView(R.id.button_right)
+    SegmentedButton rightButton;
+    @BindView(R.id.buttonGroup_pickupDropoffBoth)
+    SegmentedButtonGroup pickupDropoffButtonGroup;
+    @BindView(R.id.buttonGroup_starWarsAlt)
+    SegmentedButtonGroup starWarsAltButtonGroup;
+    @BindView(R.id.buttonGroup_roundSelectedButton)
+    SegmentedButtonGroup roundSelectedButtonGroup;
 
     SegmentedButtonGroup yesNoMaybePButtonGroup;
+    SegmentedButtonGroup starWarsPButtonGroup;
+    SegmentedButtonGroup countPButtonGroup;
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -230,25 +178,27 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
 
         ArrayAdapter adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, spinnerItems);
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-//        spinner.setAdapter(adapter);
-//        spinner.setOnItemSelectedListener(this);
-//
-//        updateButton(gradientButtonGroup.getPosition());
-//        gradientButtonGroup.setOnPositionChangedListener(position -> updateButton(position));
+        spinner.setAdapter(adapter);
+        spinner.setOnItemSelectedListener(this);
 
-//        setupDynamicDrawables();
-        setupYesNoMaybeButtonGroup();
+        updateButton(gradientButtonGroup.getPosition());
+        gradientButtonGroup.setOnPositionChangedListener(position -> updateButton(position));
 
-//        // Basic checks
-//        if (starWarsButtonGroup.getButtons().size() != 3)
-//        {
-//            throw new AssertionError("Buttons size incorrect");
-//        }
-//
-//        if (!lordOfTheRingsButtonGroup.getButton(1).getText().equals("Gimli"))
-//        {
-//            throw new AssertionError("Button name is incorrect");
-//        }
+        setupDynamicDrawables();
+        setupYesNoMaybePButtonGroup();
+        setupStarWarsPButtonGroup();
+        setupCountPButtonGroup();
+
+        // Basic checks
+        if (starWarsButtonGroup.getButtons().size() != 3)
+        {
+            throw new AssertionError("Buttons size incorrect");
+        }
+
+        if (!lordOfTheRingsButtonGroup.getButton(1).getText().equals("Gimli"))
+        {
+            throw new AssertionError("Button name is incorrect");
+        }
     }
 
     @Override
@@ -261,190 +211,194 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
             case None:
                 break;
 
-//            case ChangeBorder1:
-//                lordOfTheRingsButtonGroup.setBorder(5, Color.RED, 25, 8);
-//                marvelSuperherosButtonGroup.setBorder(5, Color.BLACK, 30, 10);
-//                break;
-//
-//            case ChangeBorder2:
-//                lordOfTheRingsButtonGroup.setBorder(2, Color.RED, 25, 8);
-//                marvelSuperherosButtonGroup.setBorder(2, Color.BLACK, 30, 10);
-//                break;
-//
-//            case ChangeBackgroundColor:
-//                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getColor(getApplicationContext(),
-//                        R.color.brown_600));
-//                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getColor(getApplicationContext(),
-//                        R.color.blue_800));
-//                break;
-//
-//            case ChangeBackgroundDrawable:
-//                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getDrawable(getApplicationContext(),
-//                        R.drawable.gradient_drawable));
-//                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getDrawable(getApplicationContext(),
-//                        R.drawable.gradient_drawable_selector));
-//                break;
-//
-//            case ChangeRadius:
-//                marvelSuperherosButtonGroup.setRadius(5);
-//                DCSuperHerosButtonGroup.setRadius(50);
-//                break;
-//
-//            case ChangePositionAnimated:
-//                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), true);
-//                break;
-//
-//            case ChangePosition:
-//                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), false);
-//                break;
-//
-//            case ToggleDraggable:
-//                darthVaderButtonGroup.setDraggable(!darthVaderButtonGroup.isDraggable());
-//                break;
-//
-//            case ToggleRipple:
-//                starWarsButtonGroup.setRipple(!starWarsButtonGroup.hasRipple());
-//                break;
-//
-//            case ToggleRippleColor:
-//                starWarsButtonGroup.setRipple(starWarsButtonGroup.getRippleColor() == Color.WHITE ? Color.BLACK :
-//                        Color.WHITE);
-//                break;
-//
-//            case ChangeDivider:
-//                lordOfTheRingsButtonGroup.setDivider(Color.MAGENTA, 10, 10, 10);
-//                guysButtonGroup.setDivider(ContextCompat.getDrawable(getApplicationContext(),
-//                        R.drawable.gradient_drawable_divider), 20, 0, 0);
-//                break;
-//
-//            case ChangeAnimation:
-//                lordOfTheRingsButtonGroup.setSelectionAnimationDuration(
-//                        lordOfTheRingsButtonGroup.getSelectionAnimationDuration() == 500 ? 5000 : 500);
-//
-//                final int random = new Random().nextInt(12);
-//                lordOfTheRingsButtonGroup.setSelectionAnimationInterpolator(random);
-//                break;
-//
-//            case RemoveButtonDrawable:
-//                lordOfTheRingsButtonGroup.getButton(0).setDrawable(null);
-//                break;
-//
-//            case ChangeButtonDrawable:
-//                lordOfTheRingsButtonGroup.getButton(0).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
-//                        R.drawable.ic_b9));
-//                DCSuperHerosButtonGroup.getButton(1).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
-//                        R.drawable.ic_aragorn));
-//                break;
-//
-//            case ChangeDrawableTint:
-//                lordOfTheRingsButtonGroup.getButton(0).setSelectedDrawableTint(Color.RED);
-//                lordOfTheRingsButtonGroup.getButton(1).setDrawableTint(Color.GREEN);
-//                lordOfTheRingsButtonGroup.getButton(2).setDrawableTint(Color.BLUE);
-//                darthVaderButtonGroup.getButton(1).removeDrawableTint();
-//                break;
-//
-//            case ToggleDrawableSize:
-//                final boolean setSize = !DCSuperHerosButtonGroup.getButton(0).hasDrawableWidth();
-//                final float size = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 96.0f,
-//                        getApplicationContext().getResources().getDisplayMetrics());
-//
-//                for (SegmentedButton button : DCSuperHerosButtonGroup.getButtons())
-//                {
-//                    button.setDrawableWidth(setSize ? (int)size : -1);
-//                    button.setDrawableHeight(setSize ? (int)size : -1);
-//                }
-//                break;
-//
-//            case ChangeDrawableGravity:
-//                gradientButtonGroup.getButton(0).setDrawableGravity(Gravity.LEFT);
-//                starWarsButtonGroup.getButton(0).setDrawableGravity(Gravity.RIGHT);
-//
-//                int currentGravity = DCSuperHerosButtonGroup.getButton(0).getDrawableGravity();
-//
-//                switch (currentGravity)
-//                {
-//                    case Gravity.LEFT:
-//                        currentGravity = Gravity.TOP;
-//                        break;
-//                    case Gravity.TOP:
-//                        currentGravity = Gravity.RIGHT;
-//                        break;
-//                    case Gravity.RIGHT:
-//                        currentGravity = Gravity.BOTTOM;
-//                        break;
-//                    case Gravity.BOTTOM:
-//                        currentGravity = Gravity.LEFT;
-//                        break;
-//                }
-//
-//                DCSuperHerosButtonGroup.getButton(0).setDrawableGravity(currentGravity);
-//                break;
-//
-//            case ChangeText:
-//                lordOfTheRingsButtonGroup.getButton(0).setText("Testing");
-//                lordOfTheRingsButtonGroup.getButton(1).setText("");
-//                break;
-//
-//            case ChangeTextColor:
-//                lordOfTheRingsButtonGroup.getButton(0).setSelectedTextColor(Color.RED);
-//                lordOfTheRingsButtonGroup.getButton(1).setTextColor(Color.BLUE);
-//                gradientButtonGroup.getButton(1).removeSelectedTextColor();
-//                break;
-//
-//            case ChangeTextSize:
-//                lordOfTheRingsButtonGroup.getButton(1).setTextSize(48.0f);
-//                DCSuperHerosButtonGroup.getButton(0).setTextSize(48.0f);
-//                break;
-//
-//            case ChangeTypeface:
-//                lordOfTheRingsButtonGroup.getButton(0).setTextTypeface(Typeface.create((Typeface)null, Typeface.BOLD));
-//                break;
-//
-//            case ChangeSelectedButtonRadius:
-//            {
-//                final float radius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30.0f,
-//                        getApplicationContext().getResources().getDisplayMetrics());
-//
-//                lordOfTheRingsButtonGroup.setSelectedButtonRadius((int)radius);
-//                roundSelectedButtonGroup.setSelectedButtonRadius(0);
-//            }
-//            break;
-//
-//            case ChangeSelectedButtonBorderSolid:
-//                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 0, 0);
-//                roundSelectedButtonGroup.setSelectedBorder(0, 0, 0, 0);
-//                break;
-//
-//            case ChangeSelectedButtonBorderDashed:
-//                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 6, 3);
-//                roundSelectedButtonGroup.setSelectedBorder(16, Color.BLACK, 6, 2);
-//                break;
-//
-//            case ToggleHiddenButtons:
-//            {
-//                SegmentedButton button = gradientButtonGroup.getButton(0);
-//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-//
-//                button = starWarsButtonGroup.getButton(1);
-//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-//
-//                button = darthVaderButtonGroup.getButton(2);
-//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-//
-//                button = draggableButtonGroup.getButton(0);
-//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-//
-//                button = roundSelectedButtonGroup.getButton(2);
-//                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
-//            }
-//            break;
+            case ChangeBorder1:
+                lordOfTheRingsButtonGroup.setBorder(5, Color.RED, 25, 8);
+                marvelSuperherosButtonGroup.setBorder(5, Color.BLACK, 30, 10);
+                break;
+
+            case ChangeBorder2:
+                lordOfTheRingsButtonGroup.setBorder(2, Color.RED, 25, 8);
+                marvelSuperherosButtonGroup.setBorder(2, Color.BLACK, 30, 10);
+                break;
+
+            case ChangeBackgroundColor:
+                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getColor(getApplicationContext(),
+                    R.color.brown_600));
+                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getColor(getApplicationContext(),
+                    R.color.blue_800));
+                break;
+
+            case ChangeBackgroundDrawable:
+                lordOfTheRingsButtonGroup.setBackground(ContextCompat.getDrawable(getApplicationContext(),
+                    R.drawable.gradient_drawable));
+                lordOfTheRingsButtonGroup.setSelectedBackground(ContextCompat.getDrawable(getApplicationContext(),
+                    R.drawable.gradient_drawable_selector));
+                break;
+
+            case ChangeRadius:
+                marvelSuperherosButtonGroup.setRadius(5);
+                DCSuperHerosButtonGroup.setRadius(50);
+                break;
+
+            case ChangePositionAnimated:
+                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), true);
+                break;
+
+            case ChangePosition:
+                lordOfTheRingsButtonGroup.setPosition(((lordOfTheRingsButtonGroup.getPosition() + 1) % 3), false);
+                break;
+
+            case ToggleDraggable:
+                darthVaderButtonGroup.setDraggable(!darthVaderButtonGroup.isDraggable());
+                break;
+
+            case ToggleRipple:
+                starWarsButtonGroup.setRipple(!starWarsButtonGroup.hasRipple());
+                break;
+
+            case ToggleRippleColor:
+                starWarsButtonGroup.setRipple(starWarsButtonGroup.getRippleColor() == Color.WHITE ? Color.BLACK :
+                    Color.WHITE);
+                break;
+
+            case ChangeDivider:
+                lordOfTheRingsButtonGroup.setDivider(Color.MAGENTA, 10, 10, 10);
+                guysButtonGroup.setDivider(ContextCompat.getDrawable(getApplicationContext(),
+                    R.drawable.gradient_drawable_divider), 20, 0, 0);
+                break;
+
+            case ChangeAnimation:
+                lordOfTheRingsButtonGroup.setSelectionAnimationDuration(
+                    lordOfTheRingsButtonGroup.getSelectionAnimationDuration() == 500 ? 5000 : 500);
+
+                final int random = new Random().nextInt(12);
+                lordOfTheRingsButtonGroup.setSelectionAnimationInterpolator(random);
+                break;
+
+            case RemoveButtonDrawable:
+                lordOfTheRingsButtonGroup.getButton(0).setDrawable(null);
+                break;
+
+            case ChangeButtonDrawable:
+                lordOfTheRingsButtonGroup.getButton(0).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
+                    R.drawable.ic_b9));
+                DCSuperHerosButtonGroup.getButton(1).setDrawable(ContextCompat.getDrawable(getApplicationContext(),
+                    R.drawable.ic_aragorn));
+                break;
+
+            case ChangeDrawableTint:
+                lordOfTheRingsButtonGroup.getButton(0).setSelectedDrawableTint(Color.RED);
+                lordOfTheRingsButtonGroup.getButton(1).setDrawableTint(Color.GREEN);
+                lordOfTheRingsButtonGroup.getButton(2).setDrawableTint(Color.BLUE);
+                darthVaderButtonGroup.getButton(1).removeDrawableTint();
+                break;
+
+            case ToggleDrawableSize:
+                final boolean setSize = !DCSuperHerosButtonGroup.getButton(0).hasDrawableWidth();
+                final float size = dpToPx(96);
+
+                for (SegmentedButton button : DCSuperHerosButtonGroup.getButtons())
+                {
+                    button.setDrawableWidth(setSize ? (int)size : -1);
+                    button.setDrawableHeight(setSize ? (int)size : -1);
+                }
+                break;
+
+            case ChangeDrawableGravity:
+                gradientButtonGroup.getButton(0).setDrawableGravity(Gravity.LEFT);
+                starWarsButtonGroup.getButton(0).setDrawableGravity(Gravity.RIGHT);
+
+                int currentGravity = DCSuperHerosButtonGroup.getButton(0).getDrawableGravity();
+
+                switch (currentGravity)
+                {
+                    case Gravity.LEFT:
+                        currentGravity = Gravity.TOP;
+                        break;
+                    case Gravity.TOP:
+                        currentGravity = Gravity.RIGHT;
+                        break;
+                    case Gravity.RIGHT:
+                        currentGravity = Gravity.BOTTOM;
+                        break;
+                    case Gravity.BOTTOM:
+                        currentGravity = Gravity.LEFT;
+                        break;
+                }
+
+                DCSuperHerosButtonGroup.getButton(0).setDrawableGravity(currentGravity);
+                break;
+
+            case ChangeText:
+                lordOfTheRingsButtonGroup.getButton(0).setText("Testing");
+                lordOfTheRingsButtonGroup.getButton(1).setText("");
+                break;
+
+            case ChangeTextColor:
+                lordOfTheRingsButtonGroup.getButton(0).setSelectedTextColor(Color.RED);
+                lordOfTheRingsButtonGroup.getButton(1).setTextColor(Color.BLUE);
+                gradientButtonGroup.getButton(1).removeSelectedTextColor();
+                break;
+
+            case ChangeTextSize:
+                lordOfTheRingsButtonGroup.getButton(1).setTextSize(48.0f);
+                DCSuperHerosButtonGroup.getButton(0).setTextSize(48.0f);
+                break;
+
+            case ChangeTypeface:
+                lordOfTheRingsButtonGroup.getButton(0).setTextTypeface(Typeface.create((Typeface)null, Typeface.BOLD));
+                break;
+
+            case ChangeSelectedButtonRadius:
+            {
+                final float radius = dpToPx(30);
+
+                lordOfTheRingsButtonGroup.setSelectedButtonRadius((int)radius);
+                roundSelectedButtonGroup.setSelectedButtonRadius(0);
+            }
+            break;
+
+            case ChangeSelectedButtonBorderSolid:
+                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 0, 0);
+                roundSelectedButtonGroup.setSelectedBorder(0, 0, 0, 0);
+                break;
+
+            case ChangeSelectedButtonBorderDashed:
+                lordOfTheRingsButtonGroup.setSelectedBorder(5, Color.MAGENTA, 6, 3);
+                roundSelectedButtonGroup.setSelectedBorder(16, Color.BLACK, 6, 2);
+                break;
+
+            case ToggleHiddenButtons:
+            {
+                SegmentedButton button = gradientButtonGroup.getButton(0);
+                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+
+                button = starWarsButtonGroup.getButton(1);
+                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+
+                button = darthVaderButtonGroup.getButton(2);
+                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+
+                button = draggableButtonGroup.getButton(0);
+                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+
+                button = roundSelectedButtonGroup.getButton(2);
+                button.setVisibility(button.getVisibility() == View.VISIBLE ? View.GONE : View.VISIBLE);
+            }
+            break;
+
+            case ChangeTextSize2:
+                yesNoMaybePButtonGroup.getButton(0).setTextSize(dpToPx(36));
+                yesNoMaybePButtonGroup.getButton(1).setTextSize(dpToPx(36));
+                yesNoMaybePButtonGroup.getButton(2).setTextSize(dpToPx(36));
+                break;
 
             default:
                 break;
         }
 
         // Reset back to the normal value
-//        spinner.setSelection(0);
+        spinner.setSelection(0);
     }
 
     @Override
@@ -453,36 +407,36 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
 
     }
 
-//    @OnClick(R.id.button_changePosition)
-//    public void changePositionButton_onClick(View view)
-//    {
-//        int position = gradientButtonGroup.getPosition();
-//        position = ++position % 3;
-//        updateButton(position);
-//
-//        gradientButtonGroup.setPosition(position, true);
-//    }
-//
-//    private void setupDynamicDrawables()
-//    {
-//        final BadgeDrawable drawable = new BadgeDrawable(Color.RED, 80, 50, 3, 3);
-//        leftButton.setDrawable(drawable);
-//
-//        dynamicButtonGroup.setOnPositionChangedListener(position -> {
-//            if (position == 0)
-//            {
-//                drawable.setCount(drawable.getCount() + 1);
-//            }
-//        });
-//
-//        final Drawable drawable2 = ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_b1);
-//        rightButton.setDrawable(drawable2);
-//    }
-//
-//    private void updateButton(int position)
-//    {
-//        changePositionButton.setText("Position: " + position);
-//    }
+    @OnClick(R.id.button_changePosition)
+    public void changePositionButton_onClick(View view)
+    {
+        int position = gradientButtonGroup.getPosition();
+        position = ++position % 3;
+        updateButton(position);
+
+        gradientButtonGroup.setPosition(position, true);
+    }
+
+    private void setupDynamicDrawables()
+    {
+        final BadgeDrawable drawable = new BadgeDrawable(Color.RED, 80, 50, 3, 3);
+        leftButton.setDrawable(drawable);
+
+        dynamicButtonGroup.setOnPositionChangedListener(position -> {
+            if (position == 0)
+            {
+                drawable.setCount(drawable.getCount() + 1);
+            }
+        });
+
+        final Drawable drawable2 = ContextCompat.getDrawable(getApplicationContext(), R.drawable.ic_b1);
+        rightButton.setDrawable(drawable2);
+    }
+
+    private void updateButton(int position)
+    {
+        changePositionButton.setText("Position: " + position);
+    }
 
     private float dpToPx(float dp)
     {
@@ -504,17 +458,14 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
         return px / getResources().getDisplayMetrics().scaledDensity;
     }
 
-    @RequiresApi(api = VERSION_CODES.LOLLIPOP)
-    private void setupYesNoMaybeButtonGroup()
+    private void setupYesNoMaybePButtonGroup()
     {
-        // TODO Recreate some of the button groups in the layout manually to ensure they work the same
-        //  Once I get a few examples working, play around with the example given to me
-
         SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
         buttonGroup.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
-        ((LinearLayout.LayoutParams)buttonGroup.getLayoutParams()).setMargins((int)dpToPx(4), (int)dpToPx(4),
-                (int)dpToPx(4), (int)dpToPx(4));
-        buttonGroup.setElevation(dpToPx(2));
+        ((LayoutParams)buttonGroup.getLayoutParams()).setMargins((int)dpToPx(4), (int)dpToPx(4),
+            (int)dpToPx(4), (int)dpToPx(4));
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)
+            buttonGroup.setElevation(dpToPx(2));
         buttonGroup.setBackground(Color.WHITE);
         buttonGroup.setRadius((int)dpToPx(30));
         buttonGroup.setRipple(Color.BLACK);
@@ -522,32 +473,11 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
         buttonGroup.setSelectedBorder((int)dpToPx(2), Color.rgb(0x55, 0x55, 0x55), 0, 0);
         buttonGroup.setSelectedButtonRadius((int)dpToPx(30));
         buttonGroup.setSelectionAnimationDuration(1000);
-        buttonGroup.setOnPositionChangedListener(position -> {
-            if (yesNoMaybePButtonGroup == null)
-                return;
-
-            Log.v(TAG,
-                    "Button sizes: " + yesNoMaybePButtonGroup.getButton(0).getWidth() + " "
-                            + yesNoMaybePButtonGroup.getButton(1).getWidth() + " "
-                            + yesNoMaybePButtonGroup.getButton(2).getWidth());
-
-            // TODO This fixes the problem
-
-            // TODO requestLayout() -> That is what causes the buttons to relayout and correct size
-            // The size of the text was still updated however
-            for (int i = 0; i < 3; ++i)
-            {
-                SegmentedButton button = yesNoMaybePButtonGroup.getButton(i);
-                button.setText(button.getText());
-            }
-        });
-
-        Log.v("SegmentedButton", "Start creation");
 
         SegmentedButton yesButton = new SegmentedButton(this);
         yesButton.setText("Yes");
         yesButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
-        yesButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        yesButton.setLayoutParams(new LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
         yesButton.setTextColor(Color.BLACK);
         yesButton.setSelectedTextColor(Color.WHITE);
         yesButton.setTextSize(spToPx(24));
@@ -556,7 +486,7 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
         SegmentedButton maybeButton = new SegmentedButton(this);
         maybeButton.setText("Maybe");
         maybeButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
-        maybeButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        maybeButton.setLayoutParams(new LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
         maybeButton.setTextColor(Color.BLACK);
         maybeButton.setSelectedTextColor(Color.WHITE);
         maybeButton.setTextSize(spToPx(24));
@@ -565,80 +495,91 @@ public class MainActivity extends AppCompatActivity implements OnItemSelectedLis
         SegmentedButton noButton = new SegmentedButton(this);
         noButton.setText("No");
         noButton.setPadding((int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8), (int)dpToPx(8));
-        noButton.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        noButton.setLayoutParams(new LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
         noButton.setTextColor(Color.BLACK);
         noButton.setSelectedTextColor(Color.WHITE);
         noButton.setTextSize(spToPx(24));
         buttonGroup.addView(noButton);
 
         buttonGroup.setPosition(1, false);
-
         linearLayout.addView(buttonGroup);
         yesNoMaybePButtonGroup = buttonGroup;
+    }
 
-        Log.v("SegmentedButton", "End creation");
+    private void setupStarWarsPButtonGroup()
+    {
+        SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
+        buttonGroup.setLayoutParams(new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+        ((LinearLayout.LayoutParams)buttonGroup.getLayoutParams()).setMargins((int)dpToPx(4), (int)dpToPx(4),
+            (int)dpToPx(4), (int)dpToPx(4));
+        ((LayoutParams)buttonGroup.getLayoutParams()).gravity = Gravity.CENTER_HORIZONTAL;
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)
+            buttonGroup.setElevation(dpToPx(2));
+        buttonGroup.setBackground(getResources().getColor(R.color.red_400));
+        buttonGroup.setRadius((int)dpToPx(2));
+        buttonGroup.setRipple(getResources().getColor(R.color.red_200));
+        buttonGroup.setSelectedBackground(getResources().getColor(R.color.green_200));
+        buttonGroup.setDivider(Color.WHITE, (int)dpToPx(2), (int)dpToPx(10), (int)dpToPx(10));
 
-//        SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
-//        buttonGroup.setBorder(3, Color.LTGRAY, 0, 0);
-//
-//        String[] names = {
-//                "Two",
-//                "One",
-//                "None"
-//        };
-//
-//        buttonGroup.setOnPositionChangedListener(position -> {
-//            for (String name : names) {
-//
-//            }
-//        });
-//
-//        for (String name : names) {
-//            SegmentedButton button = new SegmentedButton(this);
-//            button.setText(name);
-//            button.setTextSize(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 96.0f,
-//                    getResources().getDisplayMetrics()));
-//            button.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, 1.0));
-//            button.setPadding(16, 16, 16, 16);
-//            button.setTextColor(Color.BLACK);
-//            button.setSelectedTextColor(Color.BLACK);
-//            buttonGroup.addView(button);
-//        }
+        SegmentedButton button1 = new SegmentedButton(this);
+        button1.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        button1.setPadding((int)dpToPx(20), (int)dpToPx(6), (int)dpToPx(20), (int)dpToPx(6));
+        button1.setDrawable(getResources().getDrawable(R.drawable.ic_b8));
+        buttonGroup.addView(button1);
 
-//        buttonGroup.setOnPositionChangedListener(new
-//                                                         SegmentedButtonGroup.OnPositionChangedListener() {
-//                                                             @Override
-//                                                             public void onPositionChanged(final int position) {
-//                                                                 if (doneSetup) {
-//                                                                     for (int i = 0; i < valnams.size(); i++) {
-//                                                                         segButArray.get(num).getButton(i)
-//                                                                                 .setSelectedTextColor(Color.WHITE);
-//                                                                         segButArray.get(num).getButton(i)
-//                                                                                 .setSelectedBackgroundColor(
-//                                                                                         getResources().getColor(
-//                                                                                                 R.color.colorPrimary));
-//                                                                     }
-//                                                                     clicked(num, position);
-//                                                                 }
-//                                                             }
-//                                                         });
-//
-//        segButArray.add(buttonGroup);
-//        LayoutParams segLayoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
-//        segLayoutParams.setMargins(32, 16, 32, 16);
-//
-//        for (int i = 0; i < valnams.size(); i++) {
-//            SegmentedButton rb = new SegmentedButton(ctx);
-//
-//            rb.setText(valnams.get(i));
-//            rb.setTextSize(Globals.convertDpToPixel(18));
-//            rb.setLayoutParams(new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, (float) 1.0));
-//            rb.setPadding(16, 16, 16, 16);
-//            rb.setTextColor(Color.BLACK);
-//            rb.setSelectedTextColor(Color.BLACK);
-//            buttonGroup.addView(rb);
-//        }
-//
-//        layout.addView(buttonGroup, segLayoutParams);
+        SegmentedButton button2 = new SegmentedButton(this);
+        button2.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 2));
+        button2.setPadding((int)dpToPx(45), (int)dpToPx(6), (int)dpToPx(45), (int)dpToPx(6));
+        button2.setDrawable(getResources().getDrawable(R.drawable.ic_b9));
+        buttonGroup.addView(button2);
+
+        SegmentedButton button3 = new SegmentedButton(this);
+        button3.setLayoutParams(new LinearLayout.LayoutParams(0, LayoutParams.WRAP_CONTENT, 1));
+        button3.setPadding((int)dpToPx(20), (int)dpToPx(6), (int)dpToPx(20), (int)dpToPx(6));
+        button3.setDrawable(getResources().getDrawable(R.drawable.ic_b11));
+        buttonGroup.addView(button3);
+
+        buttonGroup.setPosition(1, false);
+        linearLayout.addView(buttonGroup);
+        starWarsPButtonGroup = buttonGroup;
+    }
+
+    private void setupCountPButtonGroup()
+    {
+        SegmentedButtonGroup buttonGroup = new SegmentedButtonGroup(this);
+        buttonGroup.setLayoutParams(new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+        ((LinearLayout.LayoutParams)buttonGroup.getLayoutParams()).setMargins((int)dpToPx(32), (int)dpToPx(16),
+            (int)dpToPx(32), (int)dpToPx(16));
+        ((LayoutParams)buttonGroup.getLayoutParams()).gravity = Gravity.CENTER_HORIZONTAL;
+        buttonGroup.setBorder(3, Color.LTGRAY, 0, 0);
+        buttonGroup.setDivider(Color.DKGRAY, 5, 5, 5);
+        buttonGroup.setOnPositionChangedListener(position -> {
+            if (countPButtonGroup == null)
+                return;
+
+            countPButtonGroup.getButton(2).setText(countPButtonGroup.getButton(2).getText());
+        });
+
+        String[] names = {
+            "Two",
+            "One",
+            "None"
+        };
+
+        for (String name : names)
+        {
+            SegmentedButton button = new SegmentedButton(this);
+            button.setText(name);
+            button.setTextSize(dpToPx(18));
+            button.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+            button.setPadding((int)dpToPx(20), (int)dpToPx(20), (int)dpToPx(20), (int)dpToPx(20));
+            button.setTextColor(Color.BLACK);
+            button.setSelectedTextColor(Color.WHITE);
+            button.setSelectedBackgroundColor(getResources().getColor(R.color.colorPrimary));
+            buttonGroup.addView(button);
+        }
+
+        linearLayout.addView(buttonGroup);
+        countPButtonGroup = buttonGroup;
     }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -9,11 +9,12 @@
     android:fillViewport="true">
 
     <LinearLayout
+        android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/grey_300"
         android:orientation="vertical"
-        android:paddingBottom="16dp">
+        android:paddingBottom="60dp">
 
         <Spinner
             android:id="@+id/spinner"
@@ -24,736 +25,736 @@
             android:layout_marginRight="10dp"
             android:layout_marginTop="4dp" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:layout_marginRight="10dp"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/button_changePosition"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginEnd="10dp"
-                android:layout_marginRight="10dp"
-                android:text="Position: 1" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-                android:id="@+id/buttonGroup_gradient"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:elevation="2dp"
-                android:background="@drawable/gradient_drawable"
-                app:divider="@drawable/gradient_drawable_divider"
-                app:dividerPadding="10dp"
-                app:dividerRadius="10dp"
-                app:dividerWidth="4dp"
-                app:position="1"
-                app:radius="2dp"
-                app:ripple="true"
-                app:rippleColor="@color/blue_300"
-                app:selectedBackground="@drawable/gradient_drawable_selector"
-                app:selectionAnimationDuration="1000"
-                app:selectionAnimationInterpolator="fastOutSlowIn">
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 1"
-                    app:textColor="@color/black" />
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 2"
-                    app:textColor="@color/black" />
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:selectedTextColor="@color/white"
-                    app:text="Button 3"
-                    app:textColor="@color/black" />
-            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        </LinearLayout>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_lordOfTheRings"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="#FFFFFF"
-            app:borderColor="@color/orange_700"
-            app:borderWidth="1dp"
-            app:divider="@color/orange_700"
-            app:dividerPadding="10dp"
-            app:dividerWidth="1dp"
-            app:position="0"
-            app:radius="30dp"
-            app:ripple="true"
-            app:rippleColor="@color/green_800"
-            app:selectedBackground="@color/green_900">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:fontFamily="@font/aniron"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_aragorn"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/orange_700"
-                app:text="Aragorn"
-                app:textColor="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:fontFamily="@font/aniron"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_gimli"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/grey_600"
-                app:text="Gimli"
-                app:textColor="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:fontFamily="@font/aniron"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_legolas"
-                app:drawableGravity="top"
-                app:selectedTextColor="@color/yellow_200"
-                app:text="Legolas"
-                app:textColor="@color/black" />
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_DCSuperheros"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="10dp"
-            android:elevation="2dp"
-            android:background="@color/red_700"
-            app:borderColor="@color/black"
-            app:borderWidth="1dp"
-            app:divider="@color/black"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="1dp"
-            app:radius="2dp"
-            app:selectedBackground="@color/black"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="bounce">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:drawablePadding="4dp"
-                android:fontFamily="@font/shaka_pow"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_b5"
-                app:drawableGravity="left"
-                app:rippleColor="@color/blue_500"
-                app:selectedDrawableTint="@color/yellow_500"
-                app:selectedTextColor="@color/red_500"
-                app:text="Diana"
-                app:textColor="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:drawablePadding="4dp"
-                android:fontFamily="@font/shaka_pow"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_b4"
-                app:drawableGravity="top"
-                app:rippleColor="@color/black"
-                app:selectedDrawableTint="@color/grey_500"
-                app:selectedTextColor="@color/yellow_500"
-                app:text="Batman"
-                app:textColor="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:drawablePadding="4dp"
-                android:fontFamily="@font/shaka_pow"
-                android:padding="10dp"
-                app:drawable="@drawable/ic_b3"
-                app:drawableGravity="right"
-                app:rippleColor="@color/yellow_500"
-                app:selectedDrawableTint="@color/blue_500"
-                app:selectedTextColor="@color/red_500"
-                app:text="Clark"
-                app:textColor="@color/black" />
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-                android:id="@+id/buttonGroup_marvelSuperheros"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:layout_weight="1"
-                android:elevation="2dp"
-                android:background="@color/white"
-                app:borderColor="@color/black"
-                app:borderWidth="1dp"
-                app:divider="@color/black"
-                app:dividerWidth="2dp"
-                app:position="0"
-                app:radius="30dp"
-                app:rippleColor="@color/blue_300"
-                app:selectedBackground="@color/yellow_600">
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:drawable="@drawable/ic_b1"
-                    app:drawableTint="@color/yellow_600"
-                    app:selectedDrawableTint="@color/black" />
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:drawable="@drawable/ic_b2"
-                    app:drawableTint="@color/DarkRed"
-                    app:selectedDrawableTint="@color/black" />
-
-            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-                android:id="@+id/buttonGroup_guys"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_margin="4dp"
-                android:layout_weight="1"
-                android:elevation="2dp"
-                android:background="@color/white"
-                app:divider="@color/yellow_600"
-                app:dividerWidth="2dp"
-                app:position="0"
-                app:radius="30dp"
-                app:rippleColor="@color/black"
-                app:selectedBackground="@color/DarkRed">
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:drawable="@drawable/ic_b17" />
-
-                <com.addisonelliott.segmentedbutton.SegmentedButton
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:padding="8dp"
-                    app:drawable="@drawable/ic_b6" />
-
-            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-        </LinearLayout>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_starWars"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/red_400"
-            app:divider="@color/white"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="2dp"
-            app:position="1"
-            app:radius="2dp"
-            app:rippleColor="@color/red_200"
-            app:selectedBackground="@color/green_200">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingBottom="6dp"
-                android:paddingLeft="20dp"
-                android:paddingRight="20dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b8" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                android:paddingBottom="6dp"
-                android:paddingLeft="45dp"
-                android:paddingRight="45dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b9" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:paddingBottom="6dp"
-                android:paddingLeft="20dp"
-                android:paddingRight="20dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b11" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_darthVader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/black"
-            app:position="2"
-            app:radius="2dp"
-            app:rippleColor="@color/white"
-            app:selectedBackground="@color/white"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="fastOutSlowIn">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1.5"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="2"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1.5"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                app:drawable="@drawable/ic_b7"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="10dp"
-            android:text="Draggable Segmented Group:"
-            android:textSize="12sp" />
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_draggable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/white"
-            app:borderColor="@color/black"
-            app:borderWidth="1dp"
-            app:draggable="true"
-            app:position="0"
-            app:radius="30dp"
-            app:rippleColor="@color/black"
-            app:selectedBackground="@color/green_800"
-            app:selectionAnimationDuration="1000">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="YES"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="Maybe"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="NO"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="10dp"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="10dp"
-            android:text="Using dynamic drawable:"
-            android:textSize="12sp" />
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_dynamic"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/black"
-            app:position="0"
-            app:radius="2dp"
-            app:rippleColor="@color/white"
-            app:selectedBackground="@color/white"
-            app:selectionAnimationDuration="1000"
-            app:selectionAnimationInterpolator="fastOutSlowIn">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:id="@+id/button_left"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:padding="8dp"
-                app:drawableGravity="right"
-                app:drawablePadding="8dp"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black"
-                app:text="Left" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:id="@+id/button_right"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:padding="8dp"
-                app:drawableGravity="right"
-                app:drawableTint="@color/white"
-                app:selectedDrawableTint="@color/black"
-                app:text="Right" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_pickupDropoffBoth"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:elevation="3dp"
-            android:background="@color/white"
-            app:position="0"
-            app:radius="20dp"
-            app:ripple="true"
-            app:rippleColor="@color/green_800"
-            app:selectedBackground="@color/blue_600">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:padding="4dp"
-                android:background="@color/red_100"
-                app:selectedTextColor="@color/white"
-                app:text="Both"
-                app:textColor="@color/red" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:padding="8dp"
-                android:background="@color/green_100"
-                app:selectedTextColor="@color/white"
-                app:text="Pickup"
-                app:textColor="@color/black" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:padding="4dp"
-                android:background="@color/blue_100"
-                app:selectedTextColor="@color/white"
-                app:text="Dropoff"
-                app:textColor="@color/black" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_starWarsAlt"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/red_400"
-            app:divider="@color/white"
-            app:dividerPadding="10dp"
-            app:dividerRadius="10dp"
-            app:dividerWidth="2dp"
-            app:position="0"
-            app:radius="2dp"
-            app:rippleColor="@color/red_200"
-            app:selectedBackground="@color/green_200">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="96dp"
-                android:layout_height="wrap_content"
-                android:paddingBottom="6dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b8" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="128dp"
-                android:layout_height="wrap_content"
-                android:paddingBottom="6dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b9" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="96dp"
-                android:layout_height="wrap_content"
-                android:paddingBottom="6dp"
-                android:paddingTop="6dp"
-                app:drawable="@drawable/ic_b11" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_roundSelectedButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="4dp"
-            android:elevation="2dp"
-            android:background="@color/white"
-            app:position="0"
-            app:radius="30dp"
-            app:rippleColor="@color/black"
-            app:selectedBackground="@color/blue_500"
-            app:selectedBorderColor="#555555"
-            app:selectedBorderWidth="2dp"
-            app:selectedButtonRadius="30dp"
-            app:selectionAnimationDuration="1000">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="Yes"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="@color/white"
-                app:text="Maybe"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:fontFamily="sans-serif-light"
-                android:padding="8dp"
-                app:selectedTextColor="#FFFFFF"
-                app:text="No"
-                app:textColor="@color/black"
-                app:textSize="24sp" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_rounded"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_margin="4dp"
-            app:radius="30dp"
-            app:selectedButtonRadius="30dp"
-            app:selectedBackground="@color/blue_500"
-            app:draggable="true"
-            app:ripple="true"
-            app:rippleColor="@color/blue_500">
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 2"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 3"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="8dp"
-                app:rounded="true"
-                app:selectedTextColor="@color/white"
-                app:text="Button 4"
-                app:textColor="@color/black"
-                app:textSize="20sp" />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
-
-        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
-            android:id="@+id/buttonGroup_vectorDrawable"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginLeft="4dp"
-            android:layout_marginRight="4dp"
-            android:layout_marginBottom="60dp"
-            android:weightSum="3"
-            app:draggable="true"
-            app:selectedBackground="@color/indigo_800"
-            app:borderWidth="1dp"
-            app:borderColor="@color/indigo_800"
-            app:radius="12dp"
-            app:ripple="true"
-            app:rippleColor="@color/indigo_800"
-            >
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Bar"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_bar"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Pie"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_pie"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
-
-            <com.addisonelliott.segmentedbutton.SegmentedButton
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:padding="10dp"
-                app:textColor="@color/indigo_800"
-                app:selectedTextColor="@color/white"
-                app:text="Donut"
-                app:textSize="18sp"
-                app:drawable="@drawable/ic_chart_donut"
-                app:drawableTint="@color/indigo_800"
-                app:selectedDrawableTint="@color/white"
-                app:drawableGravity="top"
-                app:drawablePadding="4dp"
-                />
-
-        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+<!--        <LinearLayout-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginLeft="10dp"-->
+<!--            android:layout_marginRight="10dp"-->
+<!--            android:orientation="horizontal">-->
+
+<!--            <Button-->
+<!--                android:id="@+id/button_changePosition"-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_gravity="center_vertical"-->
+<!--                android:layout_marginEnd="10dp"-->
+<!--                android:layout_marginRight="10dp"-->
+<!--                android:text="Position: 1" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--                android:id="@+id/buttonGroup_gradient"-->
+<!--                android:layout_width="match_parent"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_gravity="center_vertical"-->
+<!--                android:elevation="2dp"-->
+<!--                android:background="@drawable/gradient_drawable"-->
+<!--                app:divider="@drawable/gradient_drawable_divider"-->
+<!--                app:dividerPadding="10dp"-->
+<!--                app:dividerRadius="10dp"-->
+<!--                app:dividerWidth="4dp"-->
+<!--                app:position="1"-->
+<!--                app:radius="2dp"-->
+<!--                app:ripple="true"-->
+<!--                app:rippleColor="@color/blue_300"-->
+<!--                app:selectedBackground="@drawable/gradient_drawable_selector"-->
+<!--                app:selectionAnimationDuration="1000"-->
+<!--                app:selectionAnimationInterpolator="fastOutSlowIn">-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:selectedTextColor="@color/white"-->
+<!--                    app:text="Button 1"-->
+<!--                    app:textColor="@color/black" />-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:selectedTextColor="@color/white"-->
+<!--                    app:text="Button 2"-->
+<!--                    app:textColor="@color/black" />-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:selectedTextColor="@color/white"-->
+<!--                    app:text="Button 3"-->
+<!--                    app:textColor="@color/black" />-->
+<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        </LinearLayout>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_lordOfTheRings"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_gravity="center_horizontal"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="#FFFFFF"-->
+<!--            app:borderColor="@color/orange_700"-->
+<!--            app:borderWidth="1dp"-->
+<!--            app:divider="@color/orange_700"-->
+<!--            app:dividerPadding="10dp"-->
+<!--            app:dividerWidth="1dp"-->
+<!--            app:position="0"-->
+<!--            app:radius="30dp"-->
+<!--            app:ripple="true"-->
+<!--            app:rippleColor="@color/green_800"-->
+<!--            app:selectedBackground="@color/green_900">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="@font/aniron"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_aragorn"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:selectedTextColor="@color/orange_700"-->
+<!--                app:text="Aragorn"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="@font/aniron"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_gimli"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:selectedTextColor="@color/grey_600"-->
+<!--                app:text="Gimli"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="@font/aniron"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_legolas"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:selectedTextColor="@color/yellow_200"-->
+<!--                app:text="Legolas"-->
+<!--                app:textColor="@color/black" />-->
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_DCSuperheros"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="10dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/red_700"-->
+<!--            app:borderColor="@color/black"-->
+<!--            app:borderWidth="1dp"-->
+<!--            app:divider="@color/black"-->
+<!--            app:dividerPadding="10dp"-->
+<!--            app:dividerRadius="10dp"-->
+<!--            app:dividerWidth="1dp"-->
+<!--            app:radius="2dp"-->
+<!--            app:selectedBackground="@color/black"-->
+<!--            app:selectionAnimationDuration="1000"-->
+<!--            app:selectionAnimationInterpolator="bounce">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:drawablePadding="4dp"-->
+<!--                android:fontFamily="@font/shaka_pow"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_b5"-->
+<!--                app:drawableGravity="left"-->
+<!--                app:rippleColor="@color/blue_500"-->
+<!--                app:selectedDrawableTint="@color/yellow_500"-->
+<!--                app:selectedTextColor="@color/red_500"-->
+<!--                app:text="Diana"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:drawablePadding="4dp"-->
+<!--                android:fontFamily="@font/shaka_pow"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_b4"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:rippleColor="@color/black"-->
+<!--                app:selectedDrawableTint="@color/grey_500"-->
+<!--                app:selectedTextColor="@color/yellow_500"-->
+<!--                app:text="Batman"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:drawablePadding="4dp"-->
+<!--                android:fontFamily="@font/shaka_pow"-->
+<!--                android:padding="10dp"-->
+<!--                app:drawable="@drawable/ic_b3"-->
+<!--                app:drawableGravity="right"-->
+<!--                app:rippleColor="@color/yellow_500"-->
+<!--                app:selectedDrawableTint="@color/blue_500"-->
+<!--                app:selectedTextColor="@color/red_500"-->
+<!--                app:text="Clark"-->
+<!--                app:textColor="@color/black" />-->
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <LinearLayout-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:orientation="horizontal">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--                android:id="@+id/buttonGroup_marvelSuperheros"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_margin="4dp"-->
+<!--                android:layout_weight="1"-->
+<!--                android:elevation="2dp"-->
+<!--                android:background="@color/white"-->
+<!--                app:borderColor="@color/black"-->
+<!--                app:borderWidth="1dp"-->
+<!--                app:divider="@color/black"-->
+<!--                app:dividerWidth="2dp"-->
+<!--                app:position="0"-->
+<!--                app:radius="30dp"-->
+<!--                app:rippleColor="@color/blue_300"-->
+<!--                app:selectedBackground="@color/yellow_600">-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:drawable="@drawable/ic_b1"-->
+<!--                    app:drawableTint="@color/yellow_600"-->
+<!--                    app:selectedDrawableTint="@color/black" />-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:drawable="@drawable/ic_b2"-->
+<!--                    app:drawableTint="@color/DarkRed"-->
+<!--                    app:selectedDrawableTint="@color/black" />-->
+
+<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--                android:id="@+id/buttonGroup_guys"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_margin="4dp"-->
+<!--                android:layout_weight="1"-->
+<!--                android:elevation="2dp"-->
+<!--                android:background="@color/white"-->
+<!--                app:divider="@color/yellow_600"-->
+<!--                app:dividerWidth="2dp"-->
+<!--                app:position="0"-->
+<!--                app:radius="30dp"-->
+<!--                app:rippleColor="@color/black"-->
+<!--                app:selectedBackground="@color/DarkRed">-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:drawable="@drawable/ic_b17" />-->
+
+<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                    android:layout_width="0dp"-->
+<!--                    android:layout_height="wrap_content"-->
+<!--                    android:layout_weight="1"-->
+<!--                    android:padding="8dp"-->
+<!--                    app:drawable="@drawable/ic_b6" />-->
+
+<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+<!--        </LinearLayout>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_starWars"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_gravity="center_horizontal"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/red_400"-->
+<!--            app:divider="@color/white"-->
+<!--            app:dividerPadding="10dp"-->
+<!--            app:dividerRadius="10dp"-->
+<!--            app:dividerWidth="2dp"-->
+<!--            app:position="1"-->
+<!--            app:radius="2dp"-->
+<!--            app:rippleColor="@color/red_200"-->
+<!--            app:selectedBackground="@color/green_200">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingLeft="20dp"-->
+<!--                android:paddingRight="20dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b8" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="2"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingLeft="45dp"-->
+<!--                android:paddingRight="45dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b9" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingLeft="20dp"-->
+<!--                android:paddingRight="20dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b11" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_darthVader"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/black"-->
+<!--            app:position="2"-->
+<!--            app:radius="2dp"-->
+<!--            app:rippleColor="@color/white"-->
+<!--            app:selectedBackground="@color/white"-->
+<!--            app:selectionAnimationDuration="1000"-->
+<!--            app:selectionAnimationInterpolator="fastOutSlowIn">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                app:drawable="@drawable/ic_b7"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1.5"-->
+<!--                app:drawable="@drawable/ic_b7"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="2"-->
+<!--                app:drawable="@drawable/ic_b7"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1.5"-->
+<!--                app:drawable="@drawable/ic_b7"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                app:drawable="@drawable/ic_b7"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <TextView-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginLeft="10dp"-->
+<!--            android:layout_marginStart="10dp"-->
+<!--            android:layout_marginTop="10dp"-->
+<!--            android:text="Draggable Segmented Group:"-->
+<!--            android:textSize="12sp" />-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_draggable"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/white"-->
+<!--            app:borderColor="@color/black"-->
+<!--            app:borderWidth="1dp"-->
+<!--            app:draggable="true"-->
+<!--            app:position="0"-->
+<!--            app:radius="30dp"-->
+<!--            app:rippleColor="@color/black"-->
+<!--            app:selectedBackground="@color/green_800"-->
+<!--            app:selectionAnimationDuration="1000">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="YES"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Maybe"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="NO"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <TextView-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginLeft="10dp"-->
+<!--            android:layout_marginStart="10dp"-->
+<!--            android:layout_marginTop="10dp"-->
+<!--            android:text="Using dynamic drawable:"-->
+<!--            android:textSize="12sp" />-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_dynamic"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/black"-->
+<!--            app:position="0"-->
+<!--            app:radius="2dp"-->
+<!--            app:rippleColor="@color/white"-->
+<!--            app:selectedBackground="@color/white"-->
+<!--            app:selectionAnimationDuration="1000"-->
+<!--            app:selectionAnimationInterpolator="fastOutSlowIn">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:id="@+id/button_left"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="8dp"-->
+<!--                app:drawableGravity="right"-->
+<!--                app:drawablePadding="8dp"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black"-->
+<!--                app:text="Left" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:id="@+id/button_right"-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="8dp"-->
+<!--                app:drawableGravity="right"-->
+<!--                app:drawableTint="@color/white"-->
+<!--                app:selectedDrawableTint="@color/black"-->
+<!--                app:text="Right" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_pickupDropoffBoth"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="3dp"-->
+<!--            android:background="@color/white"-->
+<!--            app:position="0"-->
+<!--            app:radius="20dp"-->
+<!--            app:ripple="true"-->
+<!--            app:rippleColor="@color/green_800"-->
+<!--            app:selectedBackground="@color/blue_600">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="4dp"-->
+<!--                android:background="@color/red_100"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Both"-->
+<!--                app:textColor="@color/red" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="8dp"-->
+<!--                android:background="@color/green_100"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Pickup"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="match_parent"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="4dp"-->
+<!--                android:background="@color/blue_100"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Dropoff"-->
+<!--                app:textColor="@color/black" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_starWarsAlt"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_gravity="center_horizontal"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/red_400"-->
+<!--            app:divider="@color/white"-->
+<!--            app:dividerPadding="10dp"-->
+<!--            app:dividerRadius="10dp"-->
+<!--            app:dividerWidth="2dp"-->
+<!--            app:position="0"-->
+<!--            app:radius="2dp"-->
+<!--            app:rippleColor="@color/red_200"-->
+<!--            app:selectedBackground="@color/green_200">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="96dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b8" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="128dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b9" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="96dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:paddingBottom="6dp"-->
+<!--                android:paddingTop="6dp"-->
+<!--                app:drawable="@drawable/ic_b11" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_roundSelectedButton"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_margin="4dp"-->
+<!--            android:elevation="2dp"-->
+<!--            android:background="@color/white"-->
+<!--            app:position="0"-->
+<!--            app:radius="30dp"-->
+<!--            app:rippleColor="@color/black"-->
+<!--            app:selectedBackground="@color/blue_500"-->
+<!--            app:selectedBorderColor="#555555"-->
+<!--            app:selectedBorderWidth="2dp"-->
+<!--            app:selectedButtonRadius="30dp"-->
+<!--            app:selectionAnimationDuration="1000">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Yes"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Maybe"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:fontFamily="sans-serif-light"-->
+<!--                android:padding="8dp"-->
+<!--                app:selectedTextColor="#FFFFFF"-->
+<!--                app:text="No"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="24sp" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_rounded"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_gravity="center"-->
+<!--            android:layout_margin="4dp"-->
+<!--            app:radius="30dp"-->
+<!--            app:selectedButtonRadius="30dp"-->
+<!--            app:selectedBackground="@color/blue_500"-->
+<!--            app:draggable="true"-->
+<!--            app:ripple="true"-->
+<!--            app:rippleColor="@color/blue_500">-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:padding="8dp"-->
+<!--                app:rounded="true"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Button"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="20sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:padding="8dp"-->
+<!--                app:rounded="true"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Button 2"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="20sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:padding="8dp"-->
+<!--                app:rounded="true"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Button 3"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="20sp" />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="wrap_content"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:padding="8dp"-->
+<!--                app:rounded="true"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Button 4"-->
+<!--                app:textColor="@color/black"-->
+<!--                app:textSize="20sp" />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+
+<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
+<!--            android:id="@+id/buttonGroup_vectorDrawable"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_marginTop="4dp"-->
+<!--            android:layout_marginLeft="4dp"-->
+<!--            android:layout_marginRight="4dp"-->
+<!--            android:layout_marginBottom="6dp"-->
+<!--            android:weightSum="3"-->
+<!--            app:draggable="true"-->
+<!--            app:selectedBackground="@color/indigo_800"-->
+<!--            app:borderWidth="1dp"-->
+<!--            app:borderColor="@color/indigo_800"-->
+<!--            app:radius="12dp"-->
+<!--            app:ripple="true"-->
+<!--            app:rippleColor="@color/indigo_800"-->
+<!--            >-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="10dp"-->
+<!--                app:textColor="@color/indigo_800"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Bar"-->
+<!--                app:textSize="18sp"-->
+<!--                app:drawable="@drawable/ic_chart_bar"-->
+<!--                app:drawableTint="@color/indigo_800"-->
+<!--                app:selectedDrawableTint="@color/white"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:drawablePadding="4dp"-->
+<!--                />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="10dp"-->
+<!--                app:textColor="@color/indigo_800"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Pie"-->
+<!--                app:textSize="18sp"-->
+<!--                app:drawable="@drawable/ic_chart_pie"-->
+<!--                app:drawableTint="@color/indigo_800"-->
+<!--                app:selectedDrawableTint="@color/white"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:drawablePadding="4dp"-->
+<!--                />-->
+
+<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
+<!--                android:layout_width="0dp"-->
+<!--                android:layout_height="wrap_content"-->
+<!--                android:layout_weight="1"-->
+<!--                android:padding="10dp"-->
+<!--                app:textColor="@color/indigo_800"-->
+<!--                app:selectedTextColor="@color/white"-->
+<!--                app:text="Donut"-->
+<!--                app:textSize="18sp"-->
+<!--                app:drawable="@drawable/ic_chart_donut"-->
+<!--                app:drawableTint="@color/indigo_800"-->
+<!--                app:selectedDrawableTint="@color/white"-->
+<!--                app:drawableGravity="top"-->
+<!--                app:drawablePadding="4dp"-->
+<!--                />-->
+
+<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
     </LinearLayout>
 
 </ScrollView>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -25,736 +25,736 @@
             android:layout_marginRight="10dp"
             android:layout_marginTop="4dp" />
 
-<!--        <LinearLayout-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_marginLeft="10dp"-->
-<!--            android:layout_marginRight="10dp"-->
-<!--            android:orientation="horizontal">-->
-
-<!--            <Button-->
-<!--                android:id="@+id/button_changePosition"-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_gravity="center_vertical"-->
-<!--                android:layout_marginEnd="10dp"-->
-<!--                android:layout_marginRight="10dp"-->
-<!--                android:text="Position: 1" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--                android:id="@+id/buttonGroup_gradient"-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_gravity="center_vertical"-->
-<!--                android:elevation="2dp"-->
-<!--                android:background="@drawable/gradient_drawable"-->
-<!--                app:divider="@drawable/gradient_drawable_divider"-->
-<!--                app:dividerPadding="10dp"-->
-<!--                app:dividerRadius="10dp"-->
-<!--                app:dividerWidth="4dp"-->
-<!--                app:position="1"-->
-<!--                app:radius="2dp"-->
-<!--                app:ripple="true"-->
-<!--                app:rippleColor="@color/blue_300"-->
-<!--                app:selectedBackground="@drawable/gradient_drawable_selector"-->
-<!--                app:selectionAnimationDuration="1000"-->
-<!--                app:selectionAnimationInterpolator="fastOutSlowIn">-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:selectedTextColor="@color/white"-->
-<!--                    app:text="Button 1"-->
-<!--                    app:textColor="@color/black" />-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:selectedTextColor="@color/white"-->
-<!--                    app:text="Button 2"-->
-<!--                    app:textColor="@color/black" />-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:selectedTextColor="@color/white"-->
-<!--                    app:text="Button 3"-->
-<!--                    app:textColor="@color/black" />-->
-<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        </LinearLayout>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_lordOfTheRings"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_gravity="center_horizontal"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="#FFFFFF"-->
-<!--            app:borderColor="@color/orange_700"-->
-<!--            app:borderWidth="1dp"-->
-<!--            app:divider="@color/orange_700"-->
-<!--            app:dividerPadding="10dp"-->
-<!--            app:dividerWidth="1dp"-->
-<!--            app:position="0"-->
-<!--            app:radius="30dp"-->
-<!--            app:ripple="true"-->
-<!--            app:rippleColor="@color/green_800"-->
-<!--            app:selectedBackground="@color/green_900">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="@font/aniron"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_aragorn"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:selectedTextColor="@color/orange_700"-->
-<!--                app:text="Aragorn"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="@font/aniron"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_gimli"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:selectedTextColor="@color/grey_600"-->
-<!--                app:text="Gimli"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="@font/aniron"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_legolas"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:selectedTextColor="@color/yellow_200"-->
-<!--                app:text="Legolas"-->
-<!--                app:textColor="@color/black" />-->
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_DCSuperheros"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="10dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/red_700"-->
-<!--            app:borderColor="@color/black"-->
-<!--            app:borderWidth="1dp"-->
-<!--            app:divider="@color/black"-->
-<!--            app:dividerPadding="10dp"-->
-<!--            app:dividerRadius="10dp"-->
-<!--            app:dividerWidth="1dp"-->
-<!--            app:radius="2dp"-->
-<!--            app:selectedBackground="@color/black"-->
-<!--            app:selectionAnimationDuration="1000"-->
-<!--            app:selectionAnimationInterpolator="bounce">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:drawablePadding="4dp"-->
-<!--                android:fontFamily="@font/shaka_pow"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_b5"-->
-<!--                app:drawableGravity="left"-->
-<!--                app:rippleColor="@color/blue_500"-->
-<!--                app:selectedDrawableTint="@color/yellow_500"-->
-<!--                app:selectedTextColor="@color/red_500"-->
-<!--                app:text="Diana"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:drawablePadding="4dp"-->
-<!--                android:fontFamily="@font/shaka_pow"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_b4"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:rippleColor="@color/black"-->
-<!--                app:selectedDrawableTint="@color/grey_500"-->
-<!--                app:selectedTextColor="@color/yellow_500"-->
-<!--                app:text="Batman"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:drawablePadding="4dp"-->
-<!--                android:fontFamily="@font/shaka_pow"-->
-<!--                android:padding="10dp"-->
-<!--                app:drawable="@drawable/ic_b3"-->
-<!--                app:drawableGravity="right"-->
-<!--                app:rippleColor="@color/yellow_500"-->
-<!--                app:selectedDrawableTint="@color/blue_500"-->
-<!--                app:selectedTextColor="@color/red_500"-->
-<!--                app:text="Clark"-->
-<!--                app:textColor="@color/black" />-->
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <LinearLayout-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:orientation="horizontal">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--                android:id="@+id/buttonGroup_marvelSuperheros"-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_margin="4dp"-->
-<!--                android:layout_weight="1"-->
-<!--                android:elevation="2dp"-->
-<!--                android:background="@color/white"-->
-<!--                app:borderColor="@color/black"-->
-<!--                app:borderWidth="1dp"-->
-<!--                app:divider="@color/black"-->
-<!--                app:dividerWidth="2dp"-->
-<!--                app:position="0"-->
-<!--                app:radius="30dp"-->
-<!--                app:rippleColor="@color/blue_300"-->
-<!--                app:selectedBackground="@color/yellow_600">-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:drawable="@drawable/ic_b1"-->
-<!--                    app:drawableTint="@color/yellow_600"-->
-<!--                    app:selectedDrawableTint="@color/black" />-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:drawable="@drawable/ic_b2"-->
-<!--                    app:drawableTint="@color/DarkRed"-->
-<!--                    app:selectedDrawableTint="@color/black" />-->
-
-<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--                android:id="@+id/buttonGroup_guys"-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_margin="4dp"-->
-<!--                android:layout_weight="1"-->
-<!--                android:elevation="2dp"-->
-<!--                android:background="@color/white"-->
-<!--                app:divider="@color/yellow_600"-->
-<!--                app:dividerWidth="2dp"-->
-<!--                app:position="0"-->
-<!--                app:radius="30dp"-->
-<!--                app:rippleColor="@color/black"-->
-<!--                app:selectedBackground="@color/DarkRed">-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:drawable="@drawable/ic_b17" />-->
-
-<!--                <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                    android:layout_width="0dp"-->
-<!--                    android:layout_height="wrap_content"-->
-<!--                    android:layout_weight="1"-->
-<!--                    android:padding="8dp"-->
-<!--                    app:drawable="@drawable/ic_b6" />-->
-
-<!--            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-<!--        </LinearLayout>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_starWars"-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_gravity="center_horizontal"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/red_400"-->
-<!--            app:divider="@color/white"-->
-<!--            app:dividerPadding="10dp"-->
-<!--            app:dividerRadius="10dp"-->
-<!--            app:dividerWidth="2dp"-->
-<!--            app:position="1"-->
-<!--            app:radius="2dp"-->
-<!--            app:rippleColor="@color/red_200"-->
-<!--            app:selectedBackground="@color/green_200">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingLeft="20dp"-->
-<!--                android:paddingRight="20dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b8" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="2"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingLeft="45dp"-->
-<!--                android:paddingRight="45dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b9" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingLeft="20dp"-->
-<!--                android:paddingRight="20dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b11" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_darthVader"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/black"-->
-<!--            app:position="2"-->
-<!--            app:radius="2dp"-->
-<!--            app:rippleColor="@color/white"-->
-<!--            app:selectedBackground="@color/white"-->
-<!--            app:selectionAnimationDuration="1000"-->
-<!--            app:selectionAnimationInterpolator="fastOutSlowIn">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                app:drawable="@drawable/ic_b7"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1.5"-->
-<!--                app:drawable="@drawable/ic_b7"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="2"-->
-<!--                app:drawable="@drawable/ic_b7"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1.5"-->
-<!--                app:drawable="@drawable/ic_b7"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                app:drawable="@drawable/ic_b7"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <TextView-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_marginLeft="10dp"-->
-<!--            android:layout_marginStart="10dp"-->
-<!--            android:layout_marginTop="10dp"-->
-<!--            android:text="Draggable Segmented Group:"-->
-<!--            android:textSize="12sp" />-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_draggable"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/white"-->
-<!--            app:borderColor="@color/black"-->
-<!--            app:borderWidth="1dp"-->
-<!--            app:draggable="true"-->
-<!--            app:position="0"-->
-<!--            app:radius="30dp"-->
-<!--            app:rippleColor="@color/black"-->
-<!--            app:selectedBackground="@color/green_800"-->
-<!--            app:selectionAnimationDuration="1000">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="YES"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Maybe"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="NO"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <TextView-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_marginLeft="10dp"-->
-<!--            android:layout_marginStart="10dp"-->
-<!--            android:layout_marginTop="10dp"-->
-<!--            android:text="Using dynamic drawable:"-->
-<!--            android:textSize="12sp" />-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_dynamic"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/black"-->
-<!--            app:position="0"-->
-<!--            app:radius="2dp"-->
-<!--            app:rippleColor="@color/white"-->
-<!--            app:selectedBackground="@color/white"-->
-<!--            app:selectionAnimationDuration="1000"-->
-<!--            app:selectionAnimationInterpolator="fastOutSlowIn">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:id="@+id/button_left"-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="8dp"-->
-<!--                app:drawableGravity="right"-->
-<!--                app:drawablePadding="8dp"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black"-->
-<!--                app:text="Left" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:id="@+id/button_right"-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="8dp"-->
-<!--                app:drawableGravity="right"-->
-<!--                app:drawableTint="@color/white"-->
-<!--                app:selectedDrawableTint="@color/black"-->
-<!--                app:text="Right" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_pickupDropoffBoth"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="3dp"-->
-<!--            android:background="@color/white"-->
-<!--            app:position="0"-->
-<!--            app:radius="20dp"-->
-<!--            app:ripple="true"-->
-<!--            app:rippleColor="@color/green_800"-->
-<!--            app:selectedBackground="@color/blue_600">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="4dp"-->
-<!--                android:background="@color/red_100"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Both"-->
-<!--                app:textColor="@color/red" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="8dp"-->
-<!--                android:background="@color/green_100"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Pickup"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="match_parent"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="4dp"-->
-<!--                android:background="@color/blue_100"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Dropoff"-->
-<!--                app:textColor="@color/black" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_starWarsAlt"-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_gravity="center_horizontal"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/red_400"-->
-<!--            app:divider="@color/white"-->
-<!--            app:dividerPadding="10dp"-->
-<!--            app:dividerRadius="10dp"-->
-<!--            app:dividerWidth="2dp"-->
-<!--            app:position="0"-->
-<!--            app:radius="2dp"-->
-<!--            app:rippleColor="@color/red_200"-->
-<!--            app:selectedBackground="@color/green_200">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="96dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b8" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="128dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b9" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="96dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:paddingBottom="6dp"-->
-<!--                android:paddingTop="6dp"-->
-<!--                app:drawable="@drawable/ic_b11" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_roundSelectedButton"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_margin="4dp"-->
-<!--            android:elevation="2dp"-->
-<!--            android:background="@color/white"-->
-<!--            app:position="0"-->
-<!--            app:radius="30dp"-->
-<!--            app:rippleColor="@color/black"-->
-<!--            app:selectedBackground="@color/blue_500"-->
-<!--            app:selectedBorderColor="#555555"-->
-<!--            app:selectedBorderWidth="2dp"-->
-<!--            app:selectedButtonRadius="30dp"-->
-<!--            app:selectionAnimationDuration="1000">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Yes"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Maybe"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:fontFamily="sans-serif-light"-->
-<!--                android:padding="8dp"-->
-<!--                app:selectedTextColor="#FFFFFF"-->
-<!--                app:text="No"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="24sp" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_rounded"-->
-<!--            android:layout_width="wrap_content"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_gravity="center"-->
-<!--            android:layout_margin="4dp"-->
-<!--            app:radius="30dp"-->
-<!--            app:selectedButtonRadius="30dp"-->
-<!--            app:selectedBackground="@color/blue_500"-->
-<!--            app:draggable="true"-->
-<!--            app:ripple="true"-->
-<!--            app:rippleColor="@color/blue_500">-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:padding="8dp"-->
-<!--                app:rounded="true"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Button"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="20sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:padding="8dp"-->
-<!--                app:rounded="true"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Button 2"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="20sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:padding="8dp"-->
-<!--                app:rounded="true"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Button 3"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="20sp" />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:padding="8dp"-->
-<!--                app:rounded="true"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Button 4"-->
-<!--                app:textColor="@color/black"-->
-<!--                app:textSize="20sp" />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
-
-<!--        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup-->
-<!--            android:id="@+id/buttonGroup_vectorDrawable"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            android:layout_marginTop="4dp"-->
-<!--            android:layout_marginLeft="4dp"-->
-<!--            android:layout_marginRight="4dp"-->
-<!--            android:layout_marginBottom="6dp"-->
-<!--            android:weightSum="3"-->
-<!--            app:draggable="true"-->
-<!--            app:selectedBackground="@color/indigo_800"-->
-<!--            app:borderWidth="1dp"-->
-<!--            app:borderColor="@color/indigo_800"-->
-<!--            app:radius="12dp"-->
-<!--            app:ripple="true"-->
-<!--            app:rippleColor="@color/indigo_800"-->
-<!--            >-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="10dp"-->
-<!--                app:textColor="@color/indigo_800"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Bar"-->
-<!--                app:textSize="18sp"-->
-<!--                app:drawable="@drawable/ic_chart_bar"-->
-<!--                app:drawableTint="@color/indigo_800"-->
-<!--                app:selectedDrawableTint="@color/white"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:drawablePadding="4dp"-->
-<!--                />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="10dp"-->
-<!--                app:textColor="@color/indigo_800"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Pie"-->
-<!--                app:textSize="18sp"-->
-<!--                app:drawable="@drawable/ic_chart_pie"-->
-<!--                app:drawableTint="@color/indigo_800"-->
-<!--                app:selectedDrawableTint="@color/white"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:drawablePadding="4dp"-->
-<!--                />-->
-
-<!--            <com.addisonelliott.segmentedbutton.SegmentedButton-->
-<!--                android:layout_width="0dp"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:layout_weight="1"-->
-<!--                android:padding="10dp"-->
-<!--                app:textColor="@color/indigo_800"-->
-<!--                app:selectedTextColor="@color/white"-->
-<!--                app:text="Donut"-->
-<!--                app:textSize="18sp"-->
-<!--                app:drawable="@drawable/ic_chart_donut"-->
-<!--                app:drawableTint="@color/indigo_800"-->
-<!--                app:selectedDrawableTint="@color/white"-->
-<!--                app:drawableGravity="top"-->
-<!--                app:drawablePadding="4dp"-->
-<!--                />-->
-
-<!--        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>-->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="10dp"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_changePosition"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="10dp"
+                android:layout_marginRight="10dp"
+                android:text="Position: 1" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+                android:id="@+id/buttonGroup_gradient"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:elevation="2dp"
+                android:background="@drawable/gradient_drawable"
+                app:divider="@drawable/gradient_drawable_divider"
+                app:dividerPadding="10dp"
+                app:dividerRadius="10dp"
+                app:dividerWidth="4dp"
+                app:position="1"
+                app:radius="2dp"
+                app:ripple="true"
+                app:rippleColor="@color/blue_300"
+                app:selectedBackground="@drawable/gradient_drawable_selector"
+                app:selectionAnimationDuration="1000"
+                app:selectionAnimationInterpolator="fastOutSlowIn">
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:selectedTextColor="@color/white"
+                    app:text="Button 1"
+                    app:textColor="@color/black" />
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:selectedTextColor="@color/white"
+                    app:text="Button 2"
+                    app:textColor="@color/black" />
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:selectedTextColor="@color/white"
+                    app:text="Button 3"
+                    app:textColor="@color/black" />
+            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        </LinearLayout>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_lordOfTheRings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="#FFFFFF"
+            app:borderColor="@color/orange_700"
+            app:borderWidth="1dp"
+            app:divider="@color/orange_700"
+            app:dividerPadding="10dp"
+            app:dividerWidth="1dp"
+            app:position="0"
+            app:radius="30dp"
+            app:ripple="true"
+            app:rippleColor="@color/green_800"
+            app:selectedBackground="@color/green_900">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:fontFamily="@font/aniron"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_aragorn"
+                app:drawableGravity="top"
+                app:selectedTextColor="@color/orange_700"
+                app:text="Aragorn"
+                app:textColor="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:fontFamily="@font/aniron"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_gimli"
+                app:drawableGravity="top"
+                app:selectedTextColor="@color/grey_600"
+                app:text="Gimli"
+                app:textColor="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:fontFamily="@font/aniron"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_legolas"
+                app:drawableGravity="top"
+                app:selectedTextColor="@color/yellow_200"
+                app:text="Legolas"
+                app:textColor="@color/black" />
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_DCSuperheros"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:elevation="2dp"
+            android:background="@color/red_700"
+            app:borderColor="@color/black"
+            app:borderWidth="1dp"
+            app:divider="@color/black"
+            app:dividerPadding="10dp"
+            app:dividerRadius="10dp"
+            app:dividerWidth="1dp"
+            app:radius="2dp"
+            app:selectedBackground="@color/black"
+            app:selectionAnimationDuration="1000"
+            app:selectionAnimationInterpolator="bounce">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawablePadding="4dp"
+                android:fontFamily="@font/shaka_pow"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_b5"
+                app:drawableGravity="left"
+                app:rippleColor="@color/blue_500"
+                app:selectedDrawableTint="@color/yellow_500"
+                app:selectedTextColor="@color/red_500"
+                app:text="Diana"
+                app:textColor="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawablePadding="4dp"
+                android:fontFamily="@font/shaka_pow"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_b4"
+                app:drawableGravity="top"
+                app:rippleColor="@color/black"
+                app:selectedDrawableTint="@color/grey_500"
+                app:selectedTextColor="@color/yellow_500"
+                app:text="Batman"
+                app:textColor="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:drawablePadding="4dp"
+                android:fontFamily="@font/shaka_pow"
+                android:padding="10dp"
+                app:drawable="@drawable/ic_b3"
+                app:drawableGravity="right"
+                app:rippleColor="@color/yellow_500"
+                app:selectedDrawableTint="@color/blue_500"
+                app:selectedTextColor="@color/red_500"
+                app:text="Clark"
+                app:textColor="@color/black" />
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+                android:id="@+id/buttonGroup_marvelSuperheros"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="4dp"
+                android:layout_weight="1"
+                android:elevation="2dp"
+                android:background="@color/white"
+                app:borderColor="@color/black"
+                app:borderWidth="1dp"
+                app:divider="@color/black"
+                app:dividerWidth="2dp"
+                app:position="0"
+                app:radius="30dp"
+                app:rippleColor="@color/blue_300"
+                app:selectedBackground="@color/yellow_600">
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:drawable="@drawable/ic_b1"
+                    app:drawableTint="@color/yellow_600"
+                    app:selectedDrawableTint="@color/black" />
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:drawable="@drawable/ic_b2"
+                    app:drawableTint="@color/DarkRed"
+                    app:selectedDrawableTint="@color/black" />
+
+            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+            <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+                android:id="@+id/buttonGroup_guys"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="4dp"
+                android:layout_weight="1"
+                android:elevation="2dp"
+                android:background="@color/white"
+                app:divider="@color/yellow_600"
+                app:dividerWidth="2dp"
+                app:position="0"
+                app:radius="30dp"
+                app:rippleColor="@color/black"
+                app:selectedBackground="@color/DarkRed">
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:drawable="@drawable/ic_b17" />
+
+                <com.addisonelliott.segmentedbutton.SegmentedButton
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:padding="8dp"
+                    app:drawable="@drawable/ic_b6" />
+
+            </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+        </LinearLayout>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_starWars"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/red_400"
+            app:divider="@color/white"
+            app:dividerPadding="10dp"
+            app:dividerRadius="10dp"
+            app:dividerWidth="2dp"
+            app:position="1"
+            app:radius="2dp"
+            app:rippleColor="@color/red_200"
+            app:selectedBackground="@color/green_200">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingBottom="6dp"
+                android:paddingLeft="20dp"
+                android:paddingRight="20dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b8" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:paddingBottom="6dp"
+                android:paddingLeft="45dp"
+                android:paddingRight="45dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b9" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingBottom="6dp"
+                android:paddingLeft="20dp"
+                android:paddingRight="20dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b11" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_darthVader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/black"
+            app:position="2"
+            app:radius="2dp"
+            app:rippleColor="@color/white"
+            app:selectedBackground="@color/white"
+            app:selectionAnimationDuration="1000"
+            app:selectionAnimationInterpolator="fastOutSlowIn">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:drawable="@drawable/ic_b7"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1.5"
+                app:drawable="@drawable/ic_b7"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                app:drawable="@drawable/ic_b7"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1.5"
+                app:drawable="@drawable/ic_b7"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:drawable="@drawable/ic_b7"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:text="Draggable Segmented Group:"
+            android:textSize="12sp" />
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_draggable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/white"
+            app:borderColor="@color/black"
+            app:borderWidth="1dp"
+            app:draggable="true"
+            app:position="0"
+            app:radius="30dp"
+            app:rippleColor="@color/black"
+            app:selectedBackground="@color/green_800"
+            app:selectionAnimationDuration="1000">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="YES"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="Maybe"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="NO"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:text="Using dynamic drawable:"
+            android:textSize="12sp" />
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_dynamic"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/black"
+            app:position="0"
+            app:radius="2dp"
+            app:rippleColor="@color/white"
+            app:selectedBackground="@color/white"
+            app:selectionAnimationDuration="1000"
+            app:selectionAnimationInterpolator="fastOutSlowIn">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:id="@+id/button_left"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:padding="8dp"
+                app:drawableGravity="right"
+                app:drawablePadding="8dp"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black"
+                app:text="Left" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:id="@+id/button_right"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:padding="8dp"
+                app:drawableGravity="right"
+                app:drawableTint="@color/white"
+                app:selectedDrawableTint="@color/black"
+                app:text="Right" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_pickupDropoffBoth"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="3dp"
+            android:background="@color/white"
+            app:position="0"
+            app:radius="20dp"
+            app:ripple="true"
+            app:rippleColor="@color/green_800"
+            app:selectedBackground="@color/blue_600">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:padding="4dp"
+                android:background="@color/red_100"
+                app:selectedTextColor="@color/white"
+                app:text="Both"
+                app:textColor="@color/red" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:padding="8dp"
+                android:background="@color/green_100"
+                app:selectedTextColor="@color/white"
+                app:text="Pickup"
+                app:textColor="@color/black" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:padding="4dp"
+                android:background="@color/blue_100"
+                app:selectedTextColor="@color/white"
+                app:text="Dropoff"
+                app:textColor="@color/black" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_starWarsAlt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/red_400"
+            app:divider="@color/white"
+            app:dividerPadding="10dp"
+            app:dividerRadius="10dp"
+            app:dividerWidth="2dp"
+            app:position="0"
+            app:radius="2dp"
+            app:rippleColor="@color/red_200"
+            app:selectedBackground="@color/green_200">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="96dp"
+                android:layout_height="wrap_content"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b8" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="128dp"
+                android:layout_height="wrap_content"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b9" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="96dp"
+                android:layout_height="wrap_content"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp"
+                app:drawable="@drawable/ic_b11" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_roundSelectedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp"
+            android:elevation="2dp"
+            android:background="@color/white"
+            app:position="0"
+            app:radius="30dp"
+            app:rippleColor="@color/black"
+            app:selectedBackground="@color/blue_500"
+            app:selectedBorderColor="#555555"
+            app:selectedBorderWidth="2dp"
+            app:selectedButtonRadius="30dp"
+            app:selectionAnimationDuration="1000">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="Yes"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="@color/white"
+                app:text="Maybe"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="sans-serif-light"
+                android:padding="8dp"
+                app:selectedTextColor="#FFFFFF"
+                app:text="No"
+                app:textColor="@color/black"
+                app:textSize="24sp" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_rounded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="4dp"
+            app:radius="30dp"
+            app:selectedButtonRadius="30dp"
+            app:selectedBackground="@color/blue_500"
+            app:draggable="true"
+            app:ripple="true"
+            app:rippleColor="@color/blue_500">
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                app:rounded="true"
+                app:selectedTextColor="@color/white"
+                app:text="Button"
+                app:textColor="@color/black"
+                app:textSize="20sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                app:rounded="true"
+                app:selectedTextColor="@color/white"
+                app:text="Button 2"
+                app:textColor="@color/black"
+                app:textSize="20sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                app:rounded="true"
+                app:selectedTextColor="@color/white"
+                app:text="Button 3"
+                app:textColor="@color/black"
+                app:textSize="20sp" />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                app:rounded="true"
+                app:selectedTextColor="@color/white"
+                app:text="Button 4"
+                app:textColor="@color/black"
+                app:textSize="20sp" />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
+
+        <com.addisonelliott.segmentedbutton.SegmentedButtonGroup
+            android:id="@+id/buttonGroup_vectorDrawable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginLeft="4dp"
+            android:layout_marginRight="4dp"
+            android:layout_marginBottom="6dp"
+            android:weightSum="3"
+            app:draggable="true"
+            app:selectedBackground="@color/indigo_800"
+            app:borderWidth="1dp"
+            app:borderColor="@color/indigo_800"
+            app:radius="12dp"
+            app:ripple="true"
+            app:rippleColor="@color/indigo_800"
+            >
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="10dp"
+                app:textColor="@color/indigo_800"
+                app:selectedTextColor="@color/white"
+                app:text="Bar"
+                app:textSize="18sp"
+                app:drawable="@drawable/ic_chart_bar"
+                app:drawableTint="@color/indigo_800"
+                app:selectedDrawableTint="@color/white"
+                app:drawableGravity="top"
+                app:drawablePadding="4dp"
+                />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="10dp"
+                app:textColor="@color/indigo_800"
+                app:selectedTextColor="@color/white"
+                app:text="Pie"
+                app:textSize="18sp"
+                app:drawable="@drawable/ic_chart_pie"
+                app:drawableTint="@color/indigo_800"
+                app:selectedDrawableTint="@color/white"
+                app:drawableGravity="top"
+                app:drawablePadding="4dp"
+                />
+
+            <com.addisonelliott.segmentedbutton.SegmentedButton
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="10dp"
+                app:textColor="@color/indigo_800"
+                app:selectedTextColor="@color/white"
+                app:text="Donut"
+                app:textSize="18sp"
+                app:drawable="@drawable/ic_chart_donut"
+                app:drawableTint="@color/indigo_800"
+                app:selectedDrawableTint="@color/white"
+                app:drawableGravity="top"
+                app:drawablePadding="4dp"
+                />
+
+        </com.addisonelliott.segmentedbutton.SegmentedButtonGroup>
     </LinearLayout>
 
 </ScrollView>


### PR DESCRIPTION
# Changes
* Fixed one bug where updating text size would not appropriately recalculate the text width
* Complete rehaul of how dividers are drawn to fix some issues

# Rehaul of Divider Info
The previous setup for drawing dividers was mimicking the LinearLayout params to correctly position the dividers in the right spot. However, this had the drawback that if a layout_weight was not specified or fixed widths were given for the buttons, then the dividers would all get drawn at the left.

The new setup is to pass the SegmentedButton class to the divider LinearLayout objects (renamed class to ButtonActor's) so that the width can be measured based on the actual width of the SegmentedButton. Some additional math is performed to offset the width by the divider width appropriately.

The EmptyView class was split into another class called ButtonActor for the divider empty view.

Added some test cases where some button groups are added at run-time to ensure that works as expected. Added test case with fixed-size buttons to ensure that is working as expected.

Fixes #21