### PR TITLE
Adding property `selectedTextStyle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Check out the [sample project](https://github.com/addisonElliott/SegmentedButton
 | app:textSize                    | `dimension`       | Font size of text                                                            |
 | android:fontFamily              | `font`            | Font for displaying text                                                     |
 | app:textStyle                   | `flag`            | Text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC` |
+| app:selectedTextStyle           | `flag`            | Selected text style, can be `Typeface.NORMAL`, `Typeface.BOLD`, and `Typeface.ITALIC` |
 
 **All layout attributes have a corresponding function in Java that can be called to change programatically. See Javadocs of source code for more information.**
 

--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -169,8 +169,8 @@ public class SegmentedButton extends View
     private int textColor, selectedTextColor;
     // Font size of the text in pixels (default value is 14sp)
     private float textSize;
-    // Typeface to use for displaying the text, this is created from the fontFamily & textStyle attributes
-    private Typeface textTypeface;
+    // Typeface for displaying the text and selected text, created from the fontFamily & textStyle attributes. Default value for selected is the text typeface.
+    private Typeface textTypeface, selectedTextTypeface;
 
     // Internal listener that is called when the visibility of this button is changed
     private OnVisibilityChangedListener onVisibilityChangedListener;
@@ -280,6 +280,7 @@ public class SegmentedButton extends View
 
         final boolean hasFontFamily = ta.hasValue(R.styleable.SegmentedButton_android_fontFamily);
         final int textStyle = ta.getInt(R.styleable.SegmentedButton_textStyle, Typeface.NORMAL);
+        final int selectedTextStyle = ta.getInt(R.styleable.SegmentedButton_selectedTextStyle, textStyle);
 
         // If a font family is present then load typeface with text style from that
         if (hasFontFamily)
@@ -290,6 +291,7 @@ public class SegmentedButton extends View
             if (VERSION.SDK_INT >= VERSION_CODES.O)
             {
                 textTypeface = Typeface.create(ta.getFont(R.styleable.SegmentedButton_android_fontFamily), textStyle);
+                selectedTextTypeface = Typeface.create(ta.getFont(R.styleable.SegmentedButton_android_fontFamily), selectedTextStyle);
             }
             else
             {
@@ -298,6 +300,7 @@ public class SegmentedButton extends View
                 if (fontFamily > 0)
                 {
                     textTypeface = Typeface.create(ResourcesCompat.getFont(context, fontFamily), textStyle);
+                    selectedTextTypeface = Typeface.create(ResourcesCompat.getFont(context, fontFamily), selectedTextStyle);
                 }
                 else
                 {
@@ -305,12 +308,15 @@ public class SegmentedButton extends View
                     // "monospace". Thus, we get the font as a string and then try to load that way
                     textTypeface = Typeface.create(ta.getString(R.styleable.SegmentedButton_android_fontFamily),
                         textStyle);
+                    selectedTextTypeface = Typeface.create(ta.getString(R.styleable.SegmentedButton_android_fontFamily),
+                        selectedTextStyle);
                 }
             }
         }
         else
         {
             textTypeface = Typeface.create((Typeface)null, textStyle);
+            selectedTextTypeface = Typeface.create((Typeface)null, selectedTextStyle);
         }
 
         ta.recycle();
@@ -638,6 +644,7 @@ public class SegmentedButton extends View
             canvas.save();
             canvas.translate(textPosition.x, textPosition.y);
             textPaint.setColor(textColor);
+            textPaint.setTypeface(textTypeface);
             textStaticLayout.draw(canvas);
             canvas.restore();
         }
@@ -735,6 +742,7 @@ public class SegmentedButton extends View
             // If a selected text color was specified, then use that, otherwise we want to default to the original
             // text color
             textPaint.setColor(hasSelectedTextColor ? selectedTextColor : textColor);
+            textPaint.setTypeface(selectedTextTypeface);
             textStaticLayout.draw(canvas);
             canvas.restore();
         }
@@ -1871,12 +1879,34 @@ public class SegmentedButton extends View
     public void setTextTypeface(final Typeface typeface)
     {
         textTypeface = typeface;
+        refreshTypeface();
+    }
 
+    /**
+     * Return the current selected typeface used for drawing text
+     */
+    public Typeface getSelectedTextTypeface()
+    {
+        return selectedTextTypeface;
+    }
+
+    /**
+     * Set a new typeface to use for drawing text when the button is selected
+     *
+     * @param typeface new typeface for selected text
+     */
+    public void setSelectedTextTypeface(final Typeface typeface)
+    {
+        selectedTextTypeface = typeface;
+        refreshTypeface();
+    }
+
+    private void refreshTypeface() {
         initText();
         requestLayout();
 
         // Calculate new positions and bounds for text & drawable
-        // This may be redundant if the case that onSizeChanged gets called but there are cases where the size doesnt
+        // This may be redundant if the case that onSizeChanged gets called but there are cases where the size doesn't
         // change but the positions still need to be recalculated
         updateSize();
     }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -37,6 +37,11 @@
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
+        <attr name="selectedTextStyle" format="integer">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
     </declare-styleable>
 
     <declare-styleable name="SegmentedButtonGroup">

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -421,6 +421,7 @@
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
                 app:selectedTextColor="@color/white"
+                app:selectedTextStyle="bold"
                 app:text="YES"
                 app:textColor="@color/black"
                 app:textSize="24sp" />
@@ -432,6 +433,7 @@
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
                 app:selectedTextColor="@color/white"
+                app:selectedTextStyle="bold"
                 app:text="Maybe"
                 app:textColor="@color/black"
                 app:textSize="24sp" />
@@ -443,6 +445,7 @@
                 android:fontFamily="sans-serif-light"
                 android:padding="8dp"
                 app:selectedTextColor="@color/white"
+                app:selectedTextStyle="bold"
                 app:text="NO"
                 app:textColor="@color/black"
                 app:textSize="24sp" />


### PR DESCRIPTION
Adding a property to define the text style to use when the button is in its selected state.

-----

Hello, 

Thanks for continuing the older repo.
With the many configuration options this component is great to customise!

While using this library, I was missing an option that I need: defining the text style for the selected button. So added this option to the library. 

-----

This Pull Request provides the option `selectedTextStyle` to the `SegmentedButton`:

- The available typeface options are the same as the ones for the `app:textStyle`
- By default, the selected text style is the text style as defined by the `app:textStyle` attribute.
- Also added a getter and setter for this, since all properties provide it like this
- Added the property to the README
