### PR TITLE
Fix drawable caching

### DIFF
--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -259,7 +259,7 @@ public class SegmentedButton extends View
         if (ta.hasValue(R.styleable.SegmentedButton_drawable))
         {
             int drawableResId = ta.getResourceId(R.styleable.SegmentedButton_drawable, -1);
-            drawable = readCompatDrawable(context, drawableResId);
+            drawable = readCompatDrawable(context, drawableResId).mutate();
         }
         drawablePadding = ta.getDimensionPixelSize(R.styleable.SegmentedButton_drawablePadding, 0);
         hasDrawableTint = ta.hasValue(R.styleable.SegmentedButton_drawableTint);


### PR DESCRIPTION
Fix for this issue:
`
<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:app="http://schemas.android.com/apk/res-auto"
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    android:background="@color/black"
    android:orientation="horizontal">

    <com.addisonelliott.segmentedbutton.SegmentedButton
        android:layout_width="0dp"
        android:layout_height="40dp"
        android:layout_weight="1"
        app:drawable="@drawable/some_white_icon"
        app:selectedDrawableTint="#F00" />

    <ImageView
        android:id="@+id/iv1"
        android:layout_width="0dp"
        android:layout_height="40dp"
        android:layout_weight="1"
        android:src="@drawable/some_white_icon" />

</LinearLayout>
`
Now our ImageView drawable have red tint